### PR TITLE
fix: dont add otel imports manually

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ otel_rules
 otel_pkgdep
 opentelemetry-go-auto-instrumentation
 *_cache
+example/benchmark/benchmark

--- a/README.md
+++ b/README.md
@@ -27,16 +27,6 @@ $ make test
 
 # How to Use
 
-Import `opentelemetry-go` related dependencies for context propagation:
-
-```go
-import (
-    _ "go.opentelemetry.io/otel"
-    _ "go.opentelemetry.io/otel/baggage"
-    _ "go.opentelemetry.io/otel/sdk/trace"
-)
-```
-
 Replace `go build` with the following command to build you project:
 
 ```bash
@@ -64,46 +54,7 @@ Please feel free to file a bug
 at [GitHub Issues](https://github.com/alibaba/opentelemetry-go-auto-instrumentation/issues)
 to help us enhance this project.
 
-Lastly, we've provided some examples in `example` direcory, you can try the project through those examples.
-
-### Compatibility
-
-OpenTelemetry-Go Contrib ensures compatibility with the current supported
-versions of
-the [Go language](https://golang.org/doc/devel/release#policy):
-
-> Each major Go release is supported until there are two newer major releases.
-> For example, Go 1.5 was supported until the Go 1.7 release, and Go 1.6 was supported until the Go 1.8 release.
-
-For versions of Go that are no longer supported upstream, opentelemetry-go-contrib will
-stop ensuring compatibility with these versions in the following manner:
-
-- A minor release of opentelemetry-go-contrib will be made to add support for the new
-  supported release of Go.
-- The following minor release of opentelemetry-go-contrib will remove compatibility
-  testing for the oldest (now archived upstream) version of Go. This, and
-  future, releases of opentelemetry-go-contrib may include features only supported by
-  the currently supported versions of Go.
-
-This project is tested on the following systems.
-
-| OS       | Go Version | Architecture |
-| -------- | ---------- | ------------ |
-| Ubuntu   | 1.22       | amd64        |
-| Ubuntu   | 1.21       | amd64        |
-| Ubuntu   | 1.22       | 386          |
-| Ubuntu   | 1.21       | 386          |
-| macOS 13 | 1.22       | amd64        |
-| macOS 13 | 1.21       | amd64        |
-| macOS    | 1.22       | arm64        |
-| macOS    | 1.21       | arm64        |
-| Windows  | 1.22       | amd64        |
-| Windows  | 1.21       | amd64        |
-| Windows  | 1.22       | 386          |
-| Windows  | 1.21       | 386          |
-
-While this project should work for other systems, no compatibility guarantees
-are made for those systems currently.
+Lastly, we've provided some examples in [example](/example/) direcory, you can try the project through those examples.
 
 # Community
 
@@ -117,6 +68,7 @@ Also there are several documents that you may find useful:
 - [How to add a new rule](./docs/how-to-add-a-new-rule.md)
 - [How to debug](./docs/how-to-debug.md)
 - [How to write tests for plugins](./docs/how-to-write-tests-for-plugins.md)
+- [Supported OSxCPU](./docs/compatibility.md)
 - [Supported Libraries](./docs/supported-libraries.md)
 - [Discussion on this topic at OpenTelemetry community](https://github.com/open-telemetry/community/issues/1961)
 - [面向OpenTelemetry的Golang应用无侵入插桩技术](https://mp.weixin.qq.com/s/FKCwzRB5Ujhe1stOH2ibXg)

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,0 +1,38 @@
+# Compatibility
+
+OpenTelemetry-Go Contrib ensures compatibility with the current supported
+versions of
+the [Go language](https://golang.org/doc/devel/release#policy):
+
+> Each major Go release is supported until there are two newer major releases.
+> For example, Go 1.5 was supported until the Go 1.7 release, and Go 1.6 was supported until the Go 1.8 release.
+
+For versions of Go that are no longer supported upstream, opentelemetry-go-contrib will
+stop ensuring compatibility with these versions in the following manner:
+
+- A minor release of opentelemetry-go-contrib will be made to add support for the new
+  supported release of Go.
+- The following minor release of opentelemetry-go-contrib will remove compatibility
+  testing for the oldest (now archived upstream) version of Go. This, and
+  future, releases of opentelemetry-go-contrib may include features only supported by
+  the currently supported versions of Go.
+
+This project is tested on the following systems.
+
+| OS       | Go Version | Architecture |
+| -------- | ---------- | ------------ |
+| Ubuntu   | 1.22       | amd64        |
+| Ubuntu   | 1.21       | amd64        |
+| Ubuntu   | 1.22       | 386          |
+| Ubuntu   | 1.21       | 386          |
+| macOS 13 | 1.22       | amd64        |
+| macOS 13 | 1.21       | amd64        |
+| macOS    | 1.22       | arm64        |
+| macOS    | 1.21       | arm64        |
+| Windows  | 1.22       | amd64        |
+| Windows  | 1.21       | amd64        |
+| Windows  | 1.22       | 386          |
+| Windows  | 1.21       | 386          |
+
+While this project should work for other systems, no compatibility guarantees
+are made for those systems currently.

--- a/example/benchmark/benchmark.go
+++ b/example/benchmark/benchmark.go
@@ -4,11 +4,10 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/redis/go-redis/v9"
-	_ "go.opentelemetry.io/otel"
-	_ "go.opentelemetry.io/otel/baggage"
-	_ "go.opentelemetry.io/otel/sdk/trace"
+
 	"log"
 	"net/http"
 	"time"

--- a/pkg/otel_setup.go
+++ b/pkg/otel_setup.go
@@ -4,16 +4,20 @@ package pkg
 
 import (
 	"context"
-	"github.com/alibaba/opentelemetry-go-auto-instrumentation/pkg/verifier"
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
-	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
-	"go.opentelemetry.io/otel/propagation"
-	"go.opentelemetry.io/otel/sdk/trace"
 	"log"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/alibaba/opentelemetry-go-auto-instrumentation/pkg/verifier"
+	"go.opentelemetry.io/otel"
+	_ "go.opentelemetry.io/otel"
+	_ "go.opentelemetry.io/otel/baggage"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/sdk/trace"
+	_ "go.opentelemetry.io/otel/sdk/trace"
 )
 
 // set the following environment variables based on https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables

--- a/tool/shared/ast.go
+++ b/tool/shared/ast.go
@@ -272,6 +272,15 @@ func FindFuncDecl(root *dst.File, name string) *dst.FuncDecl {
 }
 
 // AST Parser
+// @@ N.B. DST framework provides a series of RestoreResolvers such
+// as guess.New for resolving the package name from an importPath.
+// However, its strategy is simply to guess by taking last section
+// of the importpath as the package name. This can lead to issues
+// where package names like github.com/foo/v2 are resolved as v2,
+// while in reality, they might be foo. Incorrect resolutions can
+// lead to some imports that should be present being rudely removed.
+// To solve this issue, we disable DST's automatic Import management
+// and use plain AST manipulation to add imports.
 
 // ParseAstFromSnippet parses the AST from incomplete source code snippet.
 func ParseAstFromSnippet(codeSnippnet string) ([]dst.Stmt, error) {


### PR DESCRIPTION
Please review this patch to remove descrption about adding otel imports manually, that's painful for users.