### PR TITLE
chore: rename otel-go-auto-instrumentation to otelbuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 .idea
 .vscode
 otel-go-auto-instrumentation
-otel-go-auto-instrumentation-*
+otelbuild
+otelbuild-*
 *.log
 .otel-build
 vendor

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ endif
 
 # General build options
 MOD_NAME := github.com/alibaba/opentelemetry-go-auto-instrumentation
-TOOL_REL_NAME := otel-go-auto-instrumentation
+TOOL_REL_NAME := otelbuild
 
 VERSION := $(MAIN_VERSION)_$(COMMIT_ID)
 

--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ leverage OpenTelemetry to enable effective observability.
 
 # How to Build
 
-Run the following command to build `otel-go-auto-instrumentation`:
+Run the following command to build `otelbuild`:
 
 ```bash
 $ make build
 ```
 
-For all supported platforms:
+To build all supported platforms for release purpose:
 
 ```bash
 $ make all
@@ -33,22 +33,22 @@ Replace `go build` with the following command to build you project:
 
 ```bash
 # go build
-$ ./otel-go-auto-instrumentation
+$ ./otelbuild
 ```
 
 The arguments for `go build` should be placed after the `--` delimiter:
 
 ```bash
 # go build -gcflags="-m" cmd/app
-$ ./otel-go-auto-instrumentation -- -gcflags="-m" cmd/app
+$ ./otelbuild -- -gcflags="-m" cmd/app
 ```
 
 The arguments for the tool itself should be placed before the `--` delimiter:
 
 ```bash
-$ ./otel-go-auto-instrumentation -help # print help doc
-$ ./otel-go-auto-instrumentation -debuglog # print log to file
-$ ./otel-go-auto-instrumentation -verbose -- -gcflags="-m" cmd/app # print verbose log
+$ ./otelbuild -help # print help doc
+$ ./otelbuild -debuglog # print log to file
+$ ./otelbuild -verbose -- -gcflags="-m" cmd/app # print verbose log
 ```
 
 If you find any failures during the process, it's likely a bug.

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -30,11 +30,11 @@ rules include:
 - InstStructRule: Modify a struct by adding a new field.
 - InstFileRule: Add a new file to participate in the original compilation process.
 
-Once all the preprocessing is complete, `go build -toolexec otel-go-auto-instrumentation cmd/app` 
+Once all the preprocessing is complete, `go build -toolexec otelbuild cmd/app` 
 is called for compilation. The `-toolexec` parameter is the core of our automatic 
 instrumentation, used to intercept the conventional build process and replace it
 with a user-defined tool, allowing developers to customize the build process more 
-flexibly. Here, `otel-go-auto-instrumentation` is the automatic instrumentation tool,
+flexibly. Here, `otelbuild` is the automatic instrumentation tool,
 which brings us to the Instrument phase.
 
 ## Instrument

--- a/docs/how-to-add-a-new-rule.md
+++ b/docs/how-to-add-a-new-rule.md
@@ -78,7 +78,7 @@ package main
 import "os"
 func main(){ os.Setenv("hello", "world") }
 EOF
-$ ~/opentelemetry-go-auto-instrumentation/otel-go-auto-instrumentation -- main.go
+$ ~/opentelemetry-go-auto-instrumentation/otelbuild -- main.go
 $ ./main
 Setting environment variable hello to world%
 ```

--- a/docs/how-to-debug.md
+++ b/docs/how-to-debug.md
@@ -6,10 +6,10 @@
 
 ```bash
 # go build
-$ ./otel-go-auto-instrumentation -debug
+$ ./otelbuild -debug
 ```
 
-After alerting the `-debug` option, `otel-go-auto-instrumentation` will build an unoptimized binary file with more
+After alerting the `-debug` option, `otelbuild` will build an unoptimized binary file with more
 debugging information.
 
 ## 2. Check `.otel-build` directory

--- a/example/benchmark/README.md
+++ b/example/benchmark/README.md
@@ -5,7 +5,7 @@ Go to the root directory of `opentelemetry-go-auto-instrumentation` and execute 
 ```shell
 make clean && make build
 ```
-And there will be a `otel-go-auto-instrumentation` binary in the project root directory.
+And there will be a `otelbuild` binary in the project root directory.
 ### 2. run mysql & redis
 We recommend you to use docker to run mysql and redis:
 ```shell
@@ -16,7 +16,7 @@ docker run -d -p 6379:6379 redis:latest
 Change directory to `example/benchmark` and execute the following command:
 ```shell
 cd example/benchmark
-../../otel-go-auto-instrumentation
+../../otelbuild
 ```
 And there will be a `benchmark` binary in the `example/benchmark` directory.
 ### 4. set opentelemetry endpoint

--- a/pkg/otel_setup.go
+++ b/pkg/otel_setup.go
@@ -23,14 +23,14 @@ import (
 // set the following environment variables based on https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables
 // your service name: OTEL_SERVICE_NAME
 // your otlp endpoint: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-const exec_name = "otel-go-auto-instrumentation"
+const exec_name = "otelbuild"
 
 func init() {
 	path, err := os.Executable()
 	if err != nil {
 		panic(err)
 	}
-	// skip when the executable is otel-go-auto-instrumentation itself
+	// skip when the executable is otelbuild itself
 	if strings.HasSuffix(path, exec_name) {
 		return
 	}

--- a/test/infra.go
+++ b/test/infra.go
@@ -2,8 +2,6 @@ package test
 
 import (
 	"fmt"
-	"github.com/alibaba/opentelemetry-go-auto-instrumentation/pkg/verifier"
-	"github.com/alibaba/opentelemetry-go-auto-instrumentation/test/version"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -11,11 +9,14 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/alibaba/opentelemetry-go-auto-instrumentation/pkg/verifier"
+	"github.com/alibaba/opentelemetry-go-auto-instrumentation/test/version"
+
 	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/shared"
 	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/util"
 )
 
-const execName = "otel-go-auto-instrumentation"
+const execName = "otelbuild"
 
 func RunCmd(args []string) *exec.Cmd {
 	path := args[0]

--- a/tool/shared/flags.go
+++ b/tool/shared/flags.go
@@ -47,7 +47,7 @@ const (
 // is passed. This value is specified by the build system.
 var TheVersion = "1.0.0"
 
-var TheName = "otel-go-auto-instrumentation"
+var TheName = "otelbuild"
 
 func PrintTheVersion() {
 	fmt.Printf("%s version %s\n", TheName, TheVersion)


### PR DESCRIPTION
Shorter, and simplier