### PR TITLE
fix: bad initialization order of hook funcs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,15 +11,14 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       # If you want to matrix build , you can append the following list.
       matrix:
         go_version:
           - 1.21
           - 1.22
-        os:
-          - ubuntu-latest
+        os: [ubuntu-latest, windows-latest]
     steps:
     - uses: actions/checkout@v4
 

--- a/pkg/rules/test/fmt_hook.go
+++ b/pkg/rules/test/fmt_hook.go
@@ -15,7 +15,9 @@
 
 package test
 
-import "fmt"
+import (
+	"fmt"
+)
 
 func OnExitPrintf1(call fmt.CallContext, n int, err error) {
 	println("Exiting hook1....")

--- a/test/helloworld/go.mod
+++ b/test/helloworld/go.mod
@@ -1,7 +1,34 @@
 module helloworld
 
-go 1.18
+go 1.21
+
+toolchain go1.21.4
 
 replace github.com/alibaba/opentelemetry-go-auto-instrumentation => ../../../opentelemetry-go-auto-instrumentation
 
-require golang.org/x/time v0.5.0
+require (
+	github.com/alibaba/opentelemetry-go-auto-instrumentation v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/otel v1.28.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.28.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.28.0
+	go.opentelemetry.io/otel/sdk v1.28.0
+	golang.org/x/time v0.5.0
+)
+
+require (
+	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
+	github.com/go-logr/logr v1.4.2 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/google/uuid v1.6.0 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0 // indirect
+	go.opentelemetry.io/otel/metric v1.28.0 // indirect
+	go.opentelemetry.io/otel/trace v1.28.0 // indirect
+	go.opentelemetry.io/proto/otlp v1.3.1 // indirect
+	golang.org/x/net v0.26.0 // indirect
+	golang.org/x/sys v0.21.0 // indirect
+	golang.org/x/text v0.16.0 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20240701130421-f6361c86f094 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20240701130421-f6361c86f094 // indirect
+	google.golang.org/grpc v1.64.0 // indirect
+	google.golang.org/protobuf v1.34.2 // indirect
+)

--- a/tool/driver.go
+++ b/tool/driver.go
@@ -50,6 +50,7 @@ func setupLogs() {
 	} else {
 		log.SetPrefix("[" + shared.TPreprocess + "] ")
 	}
+	log.SetFlags(0)
 	if shared.DebugLog {
 		// Redirect log to debug log if required
 		debugLogPath := shared.GetLogPath(shared.DebugLogFile)

--- a/tool/instrument/fancy_jump_386.s
+++ b/tool/instrument/fancy_jump_386.s
@@ -1,0 +1,16 @@
+// Copyright (c) 2024 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//go:build ignore
+TEXT ·FancyJump(SB),NOSPLIT,$0-8
+    //TODO

--- a/tool/instrument/fancy_jump_amd64.s
+++ b/tool/instrument/fancy_jump_amd64.s
@@ -1,0 +1,22 @@
+// Copyright (c) 2024 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//go:build ignore
+TEXT ·FancyJump(SB),NOSPLIT,$0-8
+    LEAQ ·HookFuncVar(SB), AX
+    MOVQ (AX), BX
+    CMPQ BX, $0
+    JEQ invalid
+    JMP AX
+invalid:
+    RET

--- a/tool/instrument/fancy_jump_arm.s
+++ b/tool/instrument/fancy_jump_arm.s
@@ -1,0 +1,16 @@
+// Copyright (c) 2024 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//go:build ignore
+TEXT ·FancyJump(SB),NOSPLIT,$0-8
+    //TODO

--- a/tool/instrument/fancy_jump_arm64.s
+++ b/tool/instrument/fancy_jump_arm64.s
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,31 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+// Thanks weixlu for providing the ARM64 invariant
 
-import (
-	"log"
-	"os"
-
-	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool"
-	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/shared"
-)
-
-func main() {
-	shared.ParseOptions()
-	if shared.PrintVersion {
-		shared.PrintTheVersion()
-		os.Exit(0)
-	}
-	err := shared.InitOptions()
-	if err != nil {
-		log.Printf("failed to init options: %v", err)
-		os.Exit(1)
-
-	}
-	err = tool.Run()
-	if err != nil {
-		log.Printf("failed to run the tool: %v %v", err, os.Args)
-		os.Exit(1)
-	}
-}
+//go:build ignore
+TEXT ·FancyJump(SB),NOSPLIT,$0-8
+    MOVD $·HookFuncVar(SB), R0
+    MOVD (R0), R1
+    CMP ZR, R1
+    BEQ invalid
+    BL R0
+invalid:
+    RET

--- a/tool/instrument/hook.go
+++ b/tool/instrument/hook.go
@@ -1,0 +1,267 @@
+// Copyright (c) 2024 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package instrument
+
+import (
+	"embed"
+	"errors"
+	"fmt"
+	"go/token"
+	"runtime"
+	"strings"
+
+	"github.com/alibaba/opentelemetry-go-auto-instrumentation/api"
+	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/resource"
+	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/shared"
+	"github.com/dave/dst"
+)
+
+// == Code conjured by yyang, Aug. 2024 ==
+
+//------------------------------------------------------------------------------
+// Fancy Jump To Hook
+//
+// Well, this is the fanciest part of the trampoline. We want the hook function
+// to continue linking and compiling even when a suitable relocation target is
+// not found, and to correctly link when they do exist. This is not really easily
+// achievable through regular golang code. To accomplish this, we declare some
+// uintptr variables to store the address of the hook function, and then use a
+// fancy jump function implemented in assembly code to treat this variable as a
+// function pointer and jump to it to execute.
+// Since the hook function has parameters, in order to not break golang's ABI,
+// we need the golang compiler to correctly pass these parameters to the fancy
+// jump, which transparently passes them again to the final hook function and
+// executes. During linking, if the hook function does not exist, the initial
+// value of these variables is 0, and the fancy jump will not execute. If the
+// hook function does exist, they are initialized to the function address of the
+// hook function, and the fancy jump will correctly jump to them and execute.
+// The overall process is as follows:
+//
+// var HookFunc uintptr
+//
+// func FancyJumpHookFunc(callContext* CallContext, arg1 int)
+//	lea HookFunc, rax ;; Load address of hook function
+//	mov (rax), rbx    ;; Load value of hook function
+//	cmp rbx, 0        ;; Check if it correctly linked
+//	je invalid        ;; Jump to invalid if not linked
+//	jmp rax           ;; Jump to hook function
+// invalid:
+//	ret               ;; Return if not linked
+//
+// func OtelOnEnterTrampoline_foo() {
+//   ...
+//	 FancyJumpHookFunc(&callContext, 1)
+//}
+
+const FancyJumpHookFuncVar = "HookFuncVar"
+const FancyJump = "FancyJump"
+
+func (rp *RuleProcessor) newFancyJump(t *api.InstFuncRule, onEnter bool) error {
+	asm, err := selectAsmByArch()
+	if err != nil {
+		return fmt.Errorf("failed to select asm by arch: %w", err)
+	}
+	asm = strings.ReplaceAll(asm, FancyJumpHookFuncVar, makeOnXName(t, onEnter))
+	asm = strings.ReplaceAll(asm, FancyJump, jumpTarget(t, onEnter))
+	asm += "\n"
+	rp.assembly += asm
+	return nil
+}
+
+//go:embed fancy_jump_*.s
+var fancyJumpAsmFS embed.FS
+
+func selectAsmByArch() (string, error) {
+	arch := runtime.GOARCH
+	bs, err := fancyJumpAsmFS.ReadFile("fancy_jump_" + arch + ".s")
+	if err != nil {
+		return "", fmt.Errorf("failed to read fancy jump asm file: %w arch: %s",
+			err, arch)
+	}
+	content := string(bs)
+	content = shared.RemoveGoComment(content)
+	return content, nil
+}
+
+func jumpTarget(t *api.InstFuncRule, onEnter bool) string {
+	return FancyJump + makeOnXName(t, onEnter)
+}
+
+type ParamTrait struct {
+	Index          int
+	IsVaradic      bool
+	IsInterfaceAny bool
+}
+
+func getHookFunc(t *api.InstFuncRule, onEnter bool) (*dst.FuncDecl, error) {
+	res, err := resource.FindRuleFiles(t)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find rule files: %w", err)
+	}
+	for _, file := range res {
+		source, err := resource.ReadRuleFile(file)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read file %s: %w", file, err)
+		}
+		astRoot, err := shared.ParseAstFromSource(source)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse ast from source: %w", err)
+		}
+		var target *dst.FuncDecl
+		if onEnter {
+			target = shared.FindFuncDecl(astRoot, t.OnEnter)
+		} else {
+			target = shared.FindFuncDecl(astRoot, t.OnExit)
+		}
+		if target != nil {
+			return target, nil
+		}
+	}
+	return nil, errors.New("can not find hook func for rule")
+}
+
+func getHookParamTraits(t *api.InstFuncRule, onEnter bool) ([]ParamTrait, error) {
+	target, err := getHookFunc(t, onEnter)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get hook func: %w", err)
+	}
+	var attrs []ParamTrait
+	// Find which parameter is type of interface{}
+	for i, field := range target.Type.Params.List {
+		attr := ParamTrait{Index: i}
+		if shared.IsInterfaceType(field.Type) {
+			attr.IsInterfaceAny = true
+		}
+		if shared.IsEllipsis(field.Type) {
+			attr.IsVaradic = true
+		}
+		attrs = append(attrs, attr)
+	}
+	return attrs, nil
+}
+
+func (rp *RuleProcessor) callOnEnterHook(t *api.InstFuncRule, traits []ParamTrait) error {
+	if len(traits) != (len(rp.onEnterHookFunc.Type.Params.List) + 1 /*CallContext*/) {
+		return errors.New("hook param traits mismatch on enter hook")
+	}
+	// Hook: 	   func onEnterFoo(callContext* CallContext, p*[]int)
+	// Trampoline: func OtelOnEnterTrampoline_foo(p *[]int)
+	args := []dst.Expr{dst.NewIdent(TrampolineCallContextName)}
+	for idx, field := range rp.onEnterHookFunc.Type.Params.List {
+		trait := traits[idx+1 /*CallContext*/]
+		for _, name := range field.Names { // syntax of n1,n2 type
+			if trait.IsVaradic {
+				args = append(args, shared.DereferenceOf(shared.Ident(name.Name+"...")))
+			} else {
+				args = append(args, shared.DereferenceOf(dst.NewIdent(name.Name)))
+			}
+		}
+	}
+	// Call onEnter if it exists
+	fnName := jumpTarget(t, true)
+	call := shared.ExprStmt(shared.CallTo(fnName, args))
+	insertAt(rp.onEnterHookFunc, call, len(rp.onEnterHookFunc.Body.List)-1)
+	return nil
+}
+
+func (rp *RuleProcessor) callOnExitHook(t *api.InstFuncRule, traits []ParamTrait) error {
+	if len(traits) != len(rp.onExitHookFunc.Type.Params.List) {
+		return errors.New("hook param traits mismatch on exit hook")
+	}
+	// Hook: 	   func onExitFoo(ctx* CallContext, p*[]int)
+	// Trampoline: func OtelOnExitTrampoline_foo(ctx* CallContext, p *[]int)
+	var args []dst.Expr
+	for idx, field := range rp.onExitHookFunc.Type.Params.List {
+		if idx == 0 {
+			args = append(args, dst.NewIdent(TrampolineCallContextName))
+			continue
+		}
+		trait := traits[idx]
+		for _, name := range field.Names { // syntax of n1,n2 type
+			if trait.IsVaradic {
+				arg := shared.DereferenceOf(shared.Ident(name.Name + "..."))
+				args = append(args, arg)
+			} else {
+				arg := shared.DereferenceOf(dst.NewIdent(name.Name))
+				args = append(args, arg)
+			}
+		}
+	}
+	// Call onExit if it exists
+	fnName := jumpTarget(t, false)
+	call := shared.ExprStmt(shared.CallTo(fnName, args))
+	insertAtEnd(rp.onExitHookFunc, call)
+	return nil
+}
+
+func (rp *RuleProcessor) addHookFunc(t *api.InstFuncRule,
+	traits []ParamTrait, onEnter bool) error {
+	paramTypes := rp.buildTrampolineType(onEnter)
+	addCallContext(paramTypes)
+	// Hook functions may uses interface{} as parameter type, as some types of
+	// raw function is not exposed
+	err := rectifyAnyType(paramTypes, traits)
+	if err != nil {
+		return fmt.Errorf("failed to rectify any type on enter: %w", err)
+	}
+
+	// Generate uintptr hook point
+	varDecl := &dst.GenDecl{
+		Tok: token.VAR,
+		Specs: []dst.Spec{
+			&dst.ValueSpec{
+				Names: []*dst.Ident{
+					{Name: makeOnXName(t, onEnter)},
+				},
+				Type: &dst.Ident{Name: "uintptr"},
+			},
+		},
+	}
+	rp.addDecl(varDecl)
+	// Generate fancy jump hook function declaration
+	funcDecl := &dst.FuncDecl{
+		Name: dst.NewIdent(jumpTarget(t, onEnter)),
+		Type: &dst.FuncType{
+			Params: paramTypes,
+		},
+	}
+	rp.addDecl(funcDecl)
+	// Generate assembly of fancy jump, which finally jumps to hook function
+	rp.newFancyJump(t, onEnter)
+	return nil
+}
+
+func (rp *RuleProcessor) callHookFunc(t *api.InstFuncRule, onEnter bool) error {
+	traits, err := getHookParamTraits(t, onEnter)
+	if err != nil {
+		return fmt.Errorf("failed to get hook param traits: %w", err)
+	}
+	err = rp.addHookFunc(t, traits, onEnter)
+	if err != nil {
+		return fmt.Errorf("failed to add onEnter var hook decl: %w", err)
+	}
+	if onEnter {
+		err = rp.callOnEnterHook(t, traits)
+	} else {
+		err = rp.callOnExitHook(t, traits)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to call onEnter: %w", err)
+	}
+	if !rp.replenishCallContext(onEnter) {
+		return errors.New("failed to replenish context in onEnter hook")
+	}
+	return nil
+}

--- a/tool/instrument/inst_file.go
+++ b/tool/instrument/inst_file.go
@@ -63,10 +63,10 @@ func (rp *RuleProcessor) applyFileRules(bundle *resource.RuleBundle) (err error)
 			}
 		} else {
 			mode = "APPEND"
-			rp.addCompileArg(target)
+			rp.appendCompileArg(target)
 		}
 		log.Printf("Apply file rule %v by %s mode", fileName, mode)
-		shared.SaveDebugFile("file_", target)
+		shared.SaveDebugFile("file", target)
 	}
 	return nil
 }

--- a/tool/instrument/inst_struct.go
+++ b/tool/instrument/inst_struct.go
@@ -49,7 +49,7 @@ func (rp *RuleProcessor) applyStructRules(bundle *resource.RuleBundle) error {
 		if err != nil {
 			return fmt.Errorf("failed to restore ast: %w", err)
 		}
-		shared.SaveDebugFile("struct_", newFile)
+		shared.SaveDebugFile("st", newFile)
 	}
 	return nil
 }

--- a/tool/instrument/instrument.go
+++ b/tool/instrument/instrument.go
@@ -46,12 +46,19 @@ type RuleProcessor struct {
 	rawFunc         *dst.FuncDecl
 	onEnterHookFunc *dst.FuncDecl
 	onExitHookFunc  *dst.FuncDecl
-	varDecls        []dst.Decl
 	relocated       map[string]string
 	trampolineJumps []*TJump // Optimization candidates
 	callCtxDecl     *dst.GenDecl
 	callCtxMethods  []*dst.FuncDecl
+	assembly        string
 }
+
+const (
+	OtelJumpAsm      = "otel_fancy_jump.s"
+	OtelJumpSymABI   = "otel_fancy_jump_symabi"
+	OtelJumpObject   = "otel_fancy_jump.o"
+	GoDefaultArchive = "_pkg_.a"
+)
 
 func newRuleProcessor(args []string, pkgName string) *RuleProcessor {
 	// Read compilation output directory
@@ -100,8 +107,21 @@ func (rp *RuleProcessor) tryRelocated(name string) string {
 	return name
 }
 
-func (rp *RuleProcessor) addCompileArg(newArg string) {
-	rp.compileArgs = append(rp.compileArgs, newArg)
+func (rp *RuleProcessor) appendCompileArg(newArg ...string) {
+	rp.compileArgs = append(rp.compileArgs, newArg...)
+}
+
+func (rp *RuleProcessor) prependCompileArg(newArgs ...string) {
+	for i, arg := range rp.compileArgs {
+		if strings.HasSuffix(arg, "/compile") {
+			// add newarg after compile
+			rp.compileArgs = append(rp.compileArgs[:i+1],
+				append(newArgs,
+					rp.compileArgs[i+1:]...)...)
+			return
+		}
+	}
+	util.ShouldNotReachHereT("Not a compile command")
 }
 
 func (rp *RuleProcessor) replaceCompileArg(newArg string, pred func(string) bool) error {
@@ -115,6 +135,16 @@ func (rp *RuleProcessor) replaceCompileArg(newArg string, pred func(string) bool
 		}
 	}
 	return fmt.Errorf("failed to replace compile arg %v", newArg)
+}
+
+func (rp *RuleProcessor) removeCompileArg(arg string) bool {
+	for i, a := range rp.compileArgs {
+		if a == arg {
+			rp.compileArgs = append(rp.compileArgs[:i], rp.compileArgs[i+1:]...)
+			return true
+		}
+	}
+	return false
 }
 
 func (rp *RuleProcessor) applyRules(bundle *resource.RuleBundle) (err error) {
@@ -137,7 +167,7 @@ func (rp *RuleProcessor) applyRules(bundle *resource.RuleBundle) (err error) {
 	return nil
 }
 
-func matchCompileImportPath(importPath string, args []string) bool {
+func matchImportPath(importPath string, args []string) bool {
 	for _, arg := range args {
 		if arg == importPath {
 			return true
@@ -146,13 +176,134 @@ func matchCompileImportPath(importPath string, args []string) bool {
 	return false
 }
 
+// Golang has two calling convention interfaces: ABI0 and ABIInternal. To align
+// with the Go runtime, we need to generate symbol ABI for the assembly code.
+// See https://golang.org/design/27539-internal-abi for more details.
+func (rp *RuleProcessor) genSymABI(importPath, src, dst string) (string, error) {
+	util.Guarantee(importPath != "", "sanity check")
+	util.Guarantee(shared.IsAsmFile(src), "sanity check")
+
+	// Generate new symbol ABI file
+	err := compileAsm(importPath, src, dst, true)
+	if err != nil {
+		return "", fmt.Errorf("failed to gen symabi: %w", err)
+	}
+
+	// Check if -symabis flag is already in compile arguments
+	// If so, concat the old and new symabi file
+	for i, arg := range rp.compileArgs {
+		if arg == "-symabis" {
+			newSymabi := dst
+			oldSymabi := rp.compileArgs[i+1]
+			err = util.ConcatFile(oldSymabi, newSymabi)
+			if err != nil {
+				return "", fmt.Errorf("failed to concat file: %w", err)
+			}
+			return oldSymabi, nil
+		}
+	}
+
+	rp.prependCompileArg("-symabis", dst)
+	return dst, nil
+}
+
+func compileAsm(importPath, src, dst string, genSymABI bool) error {
+	util.Guarantee(importPath != "", "sanity check")
+	util.Guarantee(shared.IsAsmFile(src), "sanity check")
+	args := []string{shared.GoAsmTool()}
+	if genSymABI {
+		// Generate symbol ABI but not compile
+		args = append(args, "-gensymabis")
+	}
+	args = append(args,
+		"-o", dst,
+		"-p", importPath,
+		"-I", shared.GoIncludeDir(),
+		src,
+	)
+	err := util.RunCmd(args...)
+	if err != nil {
+		return fmt.Errorf("failed to compile asm: %w", err)
+	}
+	return nil
+}
+
+func packObject(src, dst string) error {
+	util.Guarantee(shared.IsObjectFile(src), "sanity check")
+	util.Guarantee(shared.IsArchiveFile(dst), "sanity check")
+	err := util.RunCmd(
+		shared.GoPackTool(),
+		"r",
+		dst,
+		src,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to pack object file: %w", err)
+	}
+	return nil
+}
+
+func compileRemix(args []string, bundle *resource.RuleBundle) error {
+	// Apply rules to the target bundle
+	rp := newRuleProcessor(args, bundle.PackageName)
+	err := rp.applyRules(bundle)
+	if err != nil {
+		return fmt.Errorf("failed to apply rules: %w", err)
+	}
+	if rp.assembly == "" {
+		// No assembly code generated, just compile as usual
+		err = util.RunCmd(rp.compileArgs...)
+		if err != nil {
+			return fmt.Errorf("failed to compile: %w %v", err, rp.compileArgs)
+		}
+		return nil
+	}
+
+	// Hard case, we need to compile assembly and pack it into target archive
+	// Generate symbol ABI for further compilation
+	src := filepath.Join(rp.workDir, OtelJumpAsm)
+	dst := filepath.Join(rp.workDir, OtelJumpSymABI)
+	dst, err = rp.genSymABI(bundle.ImportPath, src, dst)
+	if err != nil {
+		return fmt.Errorf("failed to gen symabi: %w", err)
+	}
+	shared.SaveDebugFile("symabi_"+rp.packageName, dst)
+
+	// Good, run final compilation after instrumentation
+	rp.removeCompileArg("-complete")
+	err = util.RunCmd(rp.compileArgs...)
+	if err != nil {
+		return fmt.Errorf("failed to run compile: %w %v", err, rp.compileArgs)
+	}
+
+	// Compile the generated assembly file
+	src = filepath.Join(rp.workDir, OtelJumpAsm)
+	dst = filepath.Join(rp.workDir, OtelJumpObject)
+	err = compileAsm(bundle.ImportPath, src, dst, false)
+	if err != nil {
+		return fmt.Errorf("failed to compile asm: %w", err)
+	}
+	shared.SaveDebugFile("obj_"+rp.packageName, dst)
+
+	// Append the assembly object file to target archive
+	src = filepath.Join(rp.workDir, OtelJumpObject)
+	dst = filepath.Join(rp.workDir, GoDefaultArchive)
+	err = packObject(src, dst)
+	if err != nil {
+		return fmt.Errorf("failed to pack object file: %w", err)
+	}
+
+	// Over.
+	return nil
+}
+
 func Instrument() error {
 	args := os.Args[2:]
 	// Is compile command?
 	if shared.IsCompileCommand(strings.Join(args, " ")) {
 		start := time.Now()
 		if shared.Verbose {
-			log.Printf("CompileCmdInit: %v\n", args)
+			log.Printf("RunInit: %v\n", args)
 		}
 		bundles, err := resource.LoadRuleBundles()
 		if err != nil {
@@ -161,22 +312,14 @@ func Instrument() error {
 		for _, bundle := range bundles {
 			util.Assert(bundle.IsValid(), "sanity check")
 			// Is compiling the target package?
-			if matchCompileImportPath(bundle.ImportPath, args) {
-				rp := newRuleProcessor(args, bundle.PackageName)
-				err = rp.applyRules(bundle)
+			if matchImportPath(bundle.ImportPath, args) {
+				err = compileRemix(args, bundle)
+				end := time.Since(start)
+				log.Printf("Instrument %v took %v\n", bundle.PackageName, end)
 				if err != nil {
-					return fmt.Errorf("failed to apply rules: %w", err)
+					return fmt.Errorf("failed to compile remix: %w", err)
 				}
-				// Good, run final compilation after instrumentation
-				err = util.RunCmd(rp.compileArgs...)
-				took := time.Since(start)
-				if !shared.Verbose {
-					log.Printf("CompileCmd: %v took %v (%v)\n",
-						bundle.ImportPath, took, bundle.PackageName)
-				} else {
-					log.Printf("CompileCmd: %v took %v\n", rp.compileArgs, took)
-				}
-				return err
+				return nil
 			}
 		}
 	}

--- a/tool/instrument/template.go
+++ b/tool/instrument/template.go
@@ -15,10 +15,6 @@
 
 package instrument
 
-// Seeing is not always believing. The following template is a bit tricky, see
-// trampoline.go for more details
-
-// Struct Template
 type CallContextImpl struct {
 	Params     []interface{}
 	ReturnVals []interface{}
@@ -78,11 +74,8 @@ func (c *CallContextImpl) SetReturnVal(idx int, val interface{}) {
 	}
 }
 
-// Variable Template
-var OtelGetStackImpl func() []byte = nil
-var OtelPrintStackImpl func([]byte) = nil
+//func OtelPrintStack()
 
-// Trampoline Template
 func OtelOnEnterTrampoline() (CallContext, bool) {
 	defer func() {
 		if err := recover(); err != nil {
@@ -90,10 +83,7 @@ func OtelOnEnterTrampoline() (CallContext, bool) {
 			if e, ok := err.(error); ok {
 				println(e.Error())
 			}
-			fetchStack, printStack := OtelGetStackImpl, OtelPrintStackImpl
-			if fetchStack != nil && printStack != nil {
-				printStack(fetchStack())
-			}
+			//OtelPrintStack()
 		}
 	}()
 	callContext := &CallContextImpl{}
@@ -108,10 +98,7 @@ func OtelOnExitTrampoline(callContext CallContext) {
 			if e, ok := err.(error); ok {
 				println(e.Error())
 			}
-			fetchStack, printStack := OtelGetStackImpl, OtelPrintStackImpl
-			if fetchStack != nil && printStack != nil {
-				printStack(fetchStack())
-			}
+			//OtelPrintStack()
 		}
 	}()
 	callContext.(*CallContextImpl).ReturnVals = []interface{}{}

--- a/tool/resource/bundle.go
+++ b/tool/resource/bundle.go
@@ -341,9 +341,6 @@ func InitRules() error {
 		if err != nil {
 			return fmt.Errorf("failed to hash rule: %w", err)
 		}
-		if shared.Verbose {
-			log.Printf("Rule %v hashed to %d", rule, h)
-		}
 		hash2Rules[h] = rule
 	}
 	return nil

--- a/tool/shared/ast.go
+++ b/tool/shared/ast.go
@@ -250,23 +250,6 @@ func AddImportForcely(root *dst.File, path string) {
 	root.Decls = append([]dst.Decl{importStmt}, root.Decls...)
 }
 
-func NewVarDecl(name string, paramTypes *dst.FieldList) *dst.GenDecl {
-	return &dst.GenDecl{
-		Tok: token.VAR,
-		Specs: []dst.Spec{
-			&dst.ValueSpec{
-				Names: []*dst.Ident{
-					{Name: name},
-				},
-				Type: &dst.FuncType{
-					Func:   false,
-					Params: paramTypes,
-				},
-			},
-		},
-	}
-}
-
 func DereferenceOf(expr dst.Expr) dst.Expr {
 	return &dst.StarExpr{X: expr}
 }

--- a/tool/util/util.go
+++ b/tool/util/util.go
@@ -123,6 +123,32 @@ func ReadFile(filePath string) (string, error) {
 
 }
 
+func AppendFile(filePath string, content string) error {
+	file, err := os.OpenFile(filePath, os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer func(file *os.File) {
+		err := file.Close()
+		if err != nil {
+			log.Fatalf("failed to close file %s: %v", file.Name(), err)
+		}
+	}(file)
+	_, err = file.WriteString(content)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func ConcatFile(dst, src string) error {
+	srcContent, err := ReadFile(src)
+	if err != nil {
+		return err
+	}
+	return AppendFile(dst, srcContent)
+}
+
 func WriteStringToFile(filePath string, content string) (string, error) {
 	file, err := os.Create(filePath)
 	if err != nil {


### PR DESCRIPTION
related to #48 

Now, the full graph of tjump is as follows:
```go
// RawFunc:
func (t *Transport) RoundTrip(req *Request) (retVal0 *Response, retVal1 error) {
	if callContext78891, _ := OtelOnEnterTrampoline_RoundTrip78891(&t, &req); false { /* NO_NEWWLINE_PLACEHOLDER */
	} else {
		defer OtelOnExitTrampoline_RoundTrip78891(callContext78891, &retVal0, &retVal1)
	}
	return t.roundTrip(req)
}
//TrampolineFunc:
func OtelOnEnterTrampoline_RoundTrip78891(t **Transport, req **Request) (CallContext, bool) {
	defer func() {
		if err := recover(); err != nil {
			println("failed to exec onEnter hook", "clientOnEnter")
			if e, ok := err.(error); ok {
				println(e.Error())
			}
			fetchStack, printStack := OtelGetStackImpl, OtelPrintStackImpl
			if fetchStack != nil && printStack != nil {
				printStack(fetchStack())
			}
		}
	}()
	callContext := &CallContextImpl78891{}
	callContext.Params = []interface{}{t, req}
	ClientOnEnterImpl(callContext, *t, *req)
	return callContext, callContext.SkipCall
}
//HookFunc:
//go:linkname clientOnEnter net/http.ClientOnEnterImpl
func clientOnEnter(call http.CallContext, t *http.Transport, req *http.Request) {
	ctx := netHttpClientInstrumenter.Start(req.Context(), netHttpRequest{
		method:  req.Method,
		url:     *req.URL,
		header:  req.Header,
		version: strconv.Itoa(req.ProtoMajor) + "." + strconv.Itoa(req.ProtoMinor),
		host:    req.Host,
		isTls:   req.TLS != nil,
	})
	req = req.WithContext(ctx)
	call.SetParam(1, req)
	data := make(map[string]interface{}, 1)
	data["ctx"] = ctx
	call.SetData(data)
	return
}
```
`otel_rules/otel_setup_inst.go` will not generate in the future, as all prerequisites are done by go linker.