### PR TITLE
chore: dont match two times

### DIFF
--- a/pkg/rules/test/rule.go
+++ b/pkg/rules/test/rule.go
@@ -74,11 +74,6 @@ func init() {
 		WithRuleName("testrule").
 		Register()
 
-	api.NewRule("fmt", "internalFn", "", `println(MyPoint{x:1024,y:512}.y)`, "").
-		WithUseRaw(true).
-		WithRuleName("testrule").
-		Register()
-
 	api.NewRule("net/http", "NewRequest", "", "onEnterNewRequest1", "").
 		WithRuleName("testrule").
 		Register()

--- a/test/helloworld_test.go
+++ b/test/helloworld_test.go
@@ -40,11 +40,9 @@ func TestRunHelloworld(t *testing.T) {
 	ExpectContains(t, stderr, "Exiting hook1")
 	ExpectContains(t, stderr, "555")
 	ExpectContains(t, stderr, "internalFn")
-	ExpectContains(t, stderr, "GCMG")
 	ExpectContains(t, stderr, "7632")
 	ExpectContains(t, stderr, "init")
 	ExpectContains(t, stderr, "init2")
-	ExpectContains(t, stderr, "512")
 	ExpectContains(t, stderr, "30258") //0x7632
 	ExpectContains(t, stderr, "GOOD")
 	ExpectNotContains(t, stderr, "BAD")

--- a/tool/resource/bundle.go
+++ b/tool/resource/bundle.go
@@ -61,49 +61,6 @@ func (rb *RuleBundle) IsValid() bool {
 			len(rb.File2StructRules) > 0)
 }
 
-func (rb *RuleBundle) Merge(new *RuleBundle) (*RuleBundle, error) {
-	if !new.IsValid() {
-		return rb, nil
-	}
-	util.Assert(rb.ImportPath == new.ImportPath, "inconsistent import path")
-	util.Assert(rb.PackageName == new.PackageName, "inconsistent package name")
-	fileRules := make(map[uint64]bool)
-	for _, h := range rb.FileRules {
-		fileRules[h] = true
-	}
-	for _, h := range new.FileRules {
-		if _, exist := fileRules[h]; !exist {
-			rb.FileRules = append(rb.FileRules, h)
-		}
-	}
-
-	for file, rules := range new.File2FuncRules {
-		if _, exist := rb.File2FuncRules[file]; !exist {
-			rb.File2FuncRules[file] = make(map[string][]uint64)
-		}
-		for fn, hashes := range rules {
-			if _, exist := rb.File2FuncRules[file][fn]; !exist {
-				rb.File2FuncRules[file][fn] = make([]uint64, 0)
-			}
-			rb.File2FuncRules[file][fn] =
-				append(rb.File2FuncRules[file][fn], hashes...)
-		}
-	}
-	for file, rules := range new.File2StructRules {
-		if _, exist := rb.File2StructRules[file]; !exist {
-			rb.File2StructRules[file] = make(map[string][]uint64)
-		}
-		for st, hashes := range rules {
-			if _, exist := rb.File2StructRules[file][st]; !exist {
-				rb.File2StructRules[file][st] = make([]uint64, 0)
-			}
-			rb.File2StructRules[file][st] =
-				append(rb.File2StructRules[file][st], hashes...)
-		}
-	}
-	return rb, nil
-}
-
 func (rb *RuleBundle) AddFile2FuncRule(file string, rule *api.InstFuncRule) {
 	fn := rule.Function + "," + rule.ReceiverType
 	util.Assert(fn != "", "sanity check")


### PR DESCRIPTION
This feature is unused, removal of it significantly simplies code and reduces compilation time.
