### PR TITLE
fix: enforce -mod=mod build mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,32 +48,26 @@ all: clean darwin_amd64 linux_amd64 windows_amd64 darwin_arm64 linux_arm64
 .PHONY: build
 build:
 	go mod tidy
-	go mod vendor
 	$(call BUILD_CMD,$(CURRENT_OS),$(CURRENT_ARCH),$(OUTPUT_BASE))
 
 darwin_amd64:
 	go mod tidy
-	go mod vendor
 	$(call BUILD_CMD,darwin,amd64,$(OUTPUT_DARWIN_AMD64))
 
 linux_amd64:
 	go mod tidy
-	go mod vendor
 	$(call BUILD_CMD,linux,amd64,$(OUTPUT_LINUX_AMD64))
 
 windows_amd64:
 	go mod tidy
-	go mod vendor
 	$(call BUILD_CMD,windows,amd64,$(OUTPUT_WINDOWS_AMD64))
 
 darwin_arm64:
 	go mod tidy
-	go mod vendor
 	$(call BUILD_CMD,darwin,arm64,$(OUTPUT_DARWIN_ARM64))
 
 linux_arm64:
 	go mod tidy
-	go mod vendor
 	$(call BUILD_CMD,linux,arm64,$(OUTPUT_LINUX_ARM64))
 
 clean:

--- a/README.md
+++ b/README.md
@@ -14,9 +14,8 @@ time. Simply replace `go build` with `otelbuild` to get started.
 
 #### Precompiled binary
 
-We recommend using the precompiled latest release version. You can visit the
-[Release](https://github.com/alibaba/opentelemetry-go-auto-instrumentation/releases)
-page to download them.
+We recommend using the latest precompiled release version. You can download it from the [Release](https://github.com/alibaba/opentelemetry-go-auto-instrumentation/releases)
+page.
 
 #### Build from source
 

--- a/test/databasesql_tests.go
+++ b/test/databasesql_tests.go
@@ -16,29 +16,30 @@ package test
 
 import (
 	"context"
-	"github.com/docker/go-connections/nat"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/modules/mysql"
 	"log"
 	"testing"
 	"time"
+
+	"github.com/docker/go-connections/nat"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/mysql"
 )
 
 func init() {
 	TestCases = append(TestCases,
-		NewGeneralTestCase("databasesql-mysql-8-access-database-test", "", "databasesql", "", "1.18", "", TestMySql8xAccessDatabase),
-		NewGeneralTestCase("databasesql-mysql-8-fetching-database-test", "", "databasesql", "", "1.18", "", TestMySql8xFetchingDatabase),
-		NewGeneralTestCase("databasesql-mysql-8-modify-data-test", "", "databasesql", "", "1.18", "", TestMySql8xModifyData),
-		NewGeneralTestCase("databasesql-mysql-8-prepared-statement-test", "", "databasesql", "", "1.18", "", TestPreparedStatement),
-		NewGeneralTestCase("databasesql-mysql-8-single-row-query-test", "", "databasesql", "", "1.18", "", TestSingleRowQuery),
-		NewGeneralTestCase("databasesql-mysql-8-single-transaction-test", "", "databasesql", "", "1.18", "", TestTransaction),
+		NewGeneralTestCase("databasesql-mysql-8-access-database-test", "databasesql", "", "", "1.18", "", TestMySql8xAccessDatabase),
+		NewGeneralTestCase("databasesql-mysql-8-fetching-database-test", "databasesql", "", "", "1.18", "", TestMySql8xFetchingDatabase),
+		NewGeneralTestCase("databasesql-mysql-8-modify-data-test", "databasesql", "", "", "1.18", "", TestMySql8xModifyData),
+		NewGeneralTestCase("databasesql-mysql-8-prepared-statement-test", "databasesql", "", "", "1.18", "", TestPreparedStatement),
+		NewGeneralTestCase("databasesql-mysql-8-single-row-query-test", "databasesql", "", "", "1.18", "", TestSingleRowQuery),
+		NewGeneralTestCase("databasesql-mysql-8-single-transaction-test", "databasesql", "", "", "1.18", "", TestTransaction),
 
-		NewGeneralTestCase("databasesql-mysql-5-access-database-test", "", "databasesql", "", "1.18", "", TestMySql5xAccessDatabase),
-		NewGeneralTestCase("databasesql-mysql-5-fetching-database-test", "", "databasesql", "", "1.18", "", TestMySql5xFetchingDatabase),
-		NewGeneralTestCase("databasesql-mysql-5-modify-data-test", "", "databasesql", "", "1.18", "", TestMySql5xModifyData),
-		NewGeneralTestCase("databasesql-mysql-5-prepared-statement-test", "", "databasesql", "", "1.18", "", TestMySql5xPreparedStatement),
-		NewGeneralTestCase("databasesql-mysql-5-single-row-query-test", "", "databasesql", "", "1.18", "", TestMySql5xSingleRowQuery),
-		NewGeneralTestCase("databasesql-mysql-5-single-transaction-test", "", "databasesql", "", "1.18", "", TestMySql5xTransaction),
+		NewGeneralTestCase("databasesql-mysql-5-access-database-test", "databasesql", "", "", "1.18", "", TestMySql5xAccessDatabase),
+		NewGeneralTestCase("databasesql-mysql-5-fetching-database-test", "databasesql", "", "", "1.18", "", TestMySql5xFetchingDatabase),
+		NewGeneralTestCase("databasesql-mysql-5-modify-data-test", "databasesql", "", "", "1.18", "", TestMySql5xModifyData),
+		NewGeneralTestCase("databasesql-mysql-5-prepared-statement-test", "databasesql", "", "", "1.18", "", TestMySql5xPreparedStatement),
+		NewGeneralTestCase("databasesql-mysql-5-single-row-query-test", "databasesql", "", "", "1.18", "", TestMySql5xSingleRowQuery),
+		NewGeneralTestCase("databasesql-mysql-5-single-transaction-test", "databasesql", "", "", "1.18", "", TestMySql5xTransaction),
 	)
 }
 

--- a/test/helloworld_test.go
+++ b/test/helloworld_test.go
@@ -17,6 +17,8 @@ package test
 import (
 	"regexp"
 	"testing"
+
+	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/util"
 )
 
 const HelloworldAppName = "helloworld"
@@ -55,4 +57,16 @@ func TestRunHelloworld(t *testing.T) {
 	if len(matches) < 1 {
 		t.Fatalf("expecting at least one match")
 	}
+}
+
+func TestBuildHelloworldWithVendor1(t *testing.T) {
+	UseApp(HelloworldAppName)
+	util.RunCmd("go", "mod", "vendor")
+	RunInstrument(t, "-debuglog")
+}
+
+func TestBuildHelloworldWithVendor2(t *testing.T) {
+	UseApp(HelloworldAppName)
+	util.RunCmd("go", "mod", "vendor")
+	RunInstrument(t, "-debuglog", "--", "-mod=vendor")
 }

--- a/tool/preprocess/dependency.go
+++ b/tool/preprocess/dependency.go
@@ -667,8 +667,7 @@ func (dp *DepProcessor) setupDeps() error {
 		log.Printf("failed to pin opentelemetry-go-auto-instrumentation itself")
 	}
 
-	// Before generating compile commands, let's run go mod tidy first
-	// to fetch all dependencies
+	// Run go mod tidy first to fetch all dependencies
 	err = runModTidy()
 	if err != nil {
 		return fmt.Errorf("failed to run mod tidy: %w", err)

--- a/tool/preprocess/preprocess.go
+++ b/tool/preprocess/preprocess.go
@@ -16,12 +16,13 @@ package preprocess
 
 import (
 	"fmt"
-	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/version"
 	"log"
 	"os"
 	"os/exec"
 	"runtime"
 	"time"
+
+	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/version"
 
 	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/resource"
 	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/util"
@@ -109,15 +110,8 @@ func runBuildWithToolexec() (string, error) {
 		args = append(args, "-gcflags=all=-N -l")
 	}
 
-	// Avoid conflicts between args and flags with -- symbol
-	// According to go1.18.10/src/flag/flag.go#parseOne
-	if len(shared.BuildArgs) > 0 {
-		if shared.Restore {
-			return "", fmt.Errorf("args are not allowed when -restore presents")
-		}
-		// Append additional build arguments provided by the user
-		args = append(args, shared.BuildArgs...)
-	}
+	// Append additional build arguments provided by the user
+	args = append(args, shared.BuildArgs...)
 
 	if shared.Restore {
 		// Dont generate any compiled binary when using -restore

--- a/tool/shared/flags.go
+++ b/tool/shared/flags.go
@@ -23,9 +23,9 @@ import (
 )
 
 const (
-	TempBuildDir    = ".otel-build"
-	BuildModeVendor = "-mod=vendor"
-	BuildModeMod    = "-mod=mod"
+	TempBuildDir = ".otel-build"
+	BuildMode    = "-mod="
+	BuildModeMod = "-mod=mod"
 )
 
 // InToolexec true means this tool is being invoked in the go build process.
@@ -92,13 +92,9 @@ func ParseOptions() {
 	// -mod=mod tells the go command to ignore the vendor directory and to
 	// automatically update go.mod, for example, when an imported package is not
 	//  provided by any known module.
-	for _, buildArg := range BuildArgs {
-		if buildArg == BuildModeVendor {
-			if Verbose {
-				fmt.Printf("Using -mod mode instead of -mod=vendor\n")
-			}
-			BuildArgs = append(BuildArgs[:0], BuildArgs[1:]...)
-			break
+	for i := len(BuildArgs) - 1; i >= 0; i-- {
+		if BuildArgs[i] == BuildMode {
+			BuildArgs = append(BuildArgs[:i], BuildArgs[i+1:]...)
 		}
 	}
 	BuildArgs = append(BuildArgs, BuildModeMod)

--- a/tool/shared/flags.go
+++ b/tool/shared/flags.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 )
 
 const (
@@ -95,7 +96,7 @@ func ParseOptions() {
 	// -mod=readonly tells the go command to ignore the vendor directory and to
 	// report an error if go.mod needs to be updated.
 	for i := len(BuildArgs) - 1; i >= 0; i-- {
-		if BuildArgs[i] == BuildMode {
+		if strings.HasPrefix(BuildArgs[i], BuildMode) {
 			BuildArgs = append(BuildArgs[:i], BuildArgs[i+1:]...)
 		}
 	}

--- a/tool/shared/flags.go
+++ b/tool/shared/flags.go
@@ -92,6 +92,8 @@ func ParseOptions() {
 	// -mod=mod tells the go command to ignore the vendor directory and to
 	// automatically update go.mod, for example, when an imported package is not
 	//  provided by any known module.
+	// -mod=readonly tells the go command to ignore the vendor directory and to
+	// report an error if go.mod needs to be updated.
 	for i := len(BuildArgs) - 1; i >= 0; i-- {
 		if BuildArgs[i] == BuildMode {
 			BuildArgs = append(BuildArgs[:i], BuildArgs[i+1:]...)

--- a/tool/shared/flags.go
+++ b/tool/shared/flags.go
@@ -100,7 +100,7 @@ func ParseOptions() {
 			BuildArgs = append(BuildArgs[:i], BuildArgs[i+1:]...)
 		}
 	}
-	BuildArgs = append(BuildArgs, BuildModeMod)
+	BuildArgs = append([]string{BuildModeMod}, BuildArgs...)
 }
 
 func InitOptions() (err error) {

--- a/tool/shared/shared.go
+++ b/tool/shared/shared.go
@@ -110,6 +110,16 @@ func GetGoModPath() (string, error) {
 	return path, nil
 }
 
+// GetGoModDir returns the directory of go.mod file.
+func GetGoModDir() (string, error) {
+	gomod, err := GetGoModPath()
+	if err != nil {
+		return "", fmt.Errorf("failed to get go.mod directory: %w", err)
+	}
+	projectDir := filepath.Dir(gomod)
+	return projectDir, nil
+}
+
 func IsGoFile(path string) bool {
 	return strings.HasSuffix(path, ".go")
 }


### PR DESCRIPTION
No matter what build mode users use, we enforce the -mod=mod.