### PR TITLE
fix: import path may have alias name

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@
 
 This project provides an automatic solution for Golang applications that want to
 leverage OpenTelemetry to enable effective observability. No code changes are
-required in the target application, and the instrumentation is done at compile
-time. Simply replace `go build` with `otelbuild` to get started.
+required in the target application, the instrumentation is done at compile
+time. Simply replacing `go build` with `otelbuild` to get started :rocket:
 
 # Installation
 
 ### Install via Bash
-For **Linux and MacOS** users, install the tool by running the following command :rocket:
+For **Linux and MacOS** users, install the tool by running the following command
 ```bash
 $ sudo curl -fsSL https://cdn.jsdelivr.net/gh/alibaba/opentelemetry-go-auto-instrumentation@main/install.sh | sudo bash
 ```

--- a/docs/anim-logo.svg
+++ b/docs/anim-logo.svg
@@ -51,9 +51,9 @@
 					width: 100%;
 					height: 400px;
 					background: linear-gradient(-45deg, #fc5c7d, #6a82fb, #05dfd7);
-					background-size: 600% 400%;
+					/* background-size: 600% 400%; */
 					animation: gradientBackground 10s ease infinite;
-					border-radius: 10px;
+					border-radius: 30px;
 					color: white;
 					text-align: center;
 				}

--- a/pkg/data/test_error.json
+++ b/pkg/data/test_error.json
@@ -13,6 +13,12 @@
         "Path": "github.com/alibaba/opentelemetry-go-auto-instrumentation/pkg/rules/test/error2"
     },
     {
+        "ImportPath": "errors",
+        "Function": "New",
+        "OnEnter": "onEnterErrorsNewAlias",
+        "Path": "github.com/alibaba/opentelemetry-go-auto-instrumentation/pkg/rules/test/error3"
+    },
+    {
         "ImportPath": "errorstest/auxiliary",
         "Function": "TestSkip",
         "OnExit": "onExitTestSkipOnly",

--- a/pkg/rules/test/error3/hook.go
+++ b/pkg/rules/test/error3/hook.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2024 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package error2
+
+import (
+	erralias "errors"
+
+	"github.com/alibaba/opentelemetry-go-auto-instrumentation/pkg/api"
+)
+
+func onEnterErrorsNewAlias(call api.CallContext, text string) {
+	// Check if alias name confuses compilation
+	_ = erralias.ErrUnsupported
+}

--- a/tool/preprocess/pkgdep.go
+++ b/tool/preprocess/pkgdep.go
@@ -33,7 +33,7 @@ func replaceImport(importPath string, code string) string {
 	return code
 }
 
-func (dp *DepProcessor) replaceOtelImports(compileCmds []string) error {
+func (dp *DepProcessor) replaceOtelImports() error {
 	moduleName, err := dp.getImportPathOf(OtelPkgDepsDir)
 	if err != nil {
 		return fmt.Errorf("failed to get import path of otel_pkg: %w", err)
@@ -42,7 +42,7 @@ func (dp *DepProcessor) replaceOtelImports(compileCmds []string) error {
 	for _, dep := range []string{OtelRules, OtelPkgDepsDir} {
 		files, err := util.ListFiles(dep)
 		if err != nil {
-			return fmt.Errorf("failed to list files during replacement: %w", err)
+			return fmt.Errorf("failed to list files: %w", err)
 		}
 		for _, file := range files {
 			// Skip non-go files as no imports within them

--- a/tool/preprocess/preprocess.go
+++ b/tool/preprocess/preprocess.go
@@ -410,7 +410,7 @@ func (dp *DepProcessor) preclean() {
 		if astRoot == nil {
 			continue
 		}
-		if shared.RemoveImport(astRoot, ruleImport) {
+		if shared.RemoveImport(astRoot, ruleImport) != nil {
 			if shared.Verbose {
 				log.Printf("Remove obsolete import %v from %v",
 					ruleImport, file)
@@ -420,7 +420,7 @@ func (dp *DepProcessor) preclean() {
 			if !dep.addImport {
 				continue
 			}
-			if shared.RemoveImport(astRoot, dep.dep) {
+			if shared.RemoveImport(astRoot, dep.dep) != nil {
 				if shared.Verbose {
 					log.Printf("Remove obsolete import %v from %v",
 						dep, file)

--- a/tool/preprocess/preprocess.go
+++ b/tool/preprocess/preprocess.go
@@ -55,7 +55,7 @@ const (
 	DryRunLog        = "dry_run.log"
 	StdRulesPrefix   = "github.com/alibaba/opentelemetry-go-auto-instrumentation/pkg/"
 	StdRulesPath     = "github.com/alibaba/opentelemetry-go-auto-instrumentation/pkg/rules"
-	apiImport        = "github.com/alibaba/opentelemetry-go-auto-instrumentation/pkg/api"
+	ApiPath          = "github.com/alibaba/opentelemetry-go-auto-instrumentation/pkg/api"
 )
 
 // @@ Change should sync with trampoline template
@@ -312,7 +312,9 @@ func (dp *DepProcessor) addExplicitImport(importPaths ...string) (err error) {
 		// Prepend import path to the file
 		for _, importPath := range importPaths {
 			shared.AddImportForcely(astRoot, importPath)
-			log.Printf("Add %s import to %v", importPath, file)
+			if shared.Verbose {
+				log.Printf("Add %s import to %v", importPath, file)
+			}
 		}
 		addImport = true
 
@@ -664,7 +666,7 @@ func (dp *DepProcessor) setupDeps() error {
 		return fmt.Errorf("failed to setup dependencies: %w", err)
 	}
 
-	err = dp.replaceOtelImports(compileCmds)
+	err = dp.replaceOtelImports()
 	if err != nil {
 		return fmt.Errorf("failed to replace otel imports: %w", err)
 	}

--- a/tool/preprocess/preprocess.go
+++ b/tool/preprocess/preprocess.go
@@ -418,17 +418,6 @@ func (dp *DepProcessor) preclean() {
 					ruleImport, file)
 			}
 		}
-		for _, dep := range fixedDeps {
-			if !dep.addImport {
-				continue
-			}
-			if shared.RemoveImport(astRoot, dep.dep) != nil {
-				if shared.Verbose {
-					log.Printf("Remove obsolete import %v from %v",
-						dep, file)
-				}
-			}
-		}
 		_, err := shared.WriteAstToFile(astRoot, file)
 		if err != nil {
 			log.Printf("Failed to write ast to %v: %v", file, err)

--- a/tool/preprocess/preprocess.go
+++ b/tool/preprocess/preprocess.go
@@ -543,7 +543,9 @@ func (dp *DepProcessor) pinDepVersion() error {
 	for _, dep := range fixedDeps {
 		p := dep.dep
 		v := dep.version
-		log.Printf("Pin dependency version %v@%v", p, v)
+		if shared.Verbose {
+			log.Printf("Pin dependency version %v@%v", p, v)
+		}
 		err := fetchDep(p + "@" + v)
 		if err != nil {
 			if dep.fallible {

--- a/tool/preprocess/setup.go
+++ b/tool/preprocess/setup.go
@@ -227,7 +227,7 @@ func (dp *DepProcessor) copyRule(path, target string,
 	makeHookPublic(astRoot, bundle)
 
 	// Rename "api" import to the correct package prefix
-	renameImport(astRoot, apiImport, bundle.ImportPath)
+	renameImport(astRoot, ApiPath, bundle.ImportPath)
 
 	// Copy used rule into project
 	_, err = shared.WriteAstToFile(astRoot, target)

--- a/tool/preprocess/setup.go
+++ b/tool/preprocess/setup.go
@@ -328,7 +328,7 @@ func (dp *DepProcessor) initRules(pkgName, target string) (err error) {
 		imports[OtelGetStackImportPath] = OtelGetStackAliasPkg
 	}
 	for k, v := range imports {
-		c += fmt.Sprintf("import %s \"%s\"\n", v, k)
+		c += fmt.Sprintf("import %s %q\n", v, k)
 	}
 
 	// Assignments

--- a/tool/shared/ast.go
+++ b/tool/shared/ast.go
@@ -246,7 +246,7 @@ func addImport(root *dst.File, path string, force bool) {
 	spec := &dst.ImportSpec{
 		Path: &dst.BasicLit{
 			Kind:  token.STRING,
-			Value: fmt.Sprintf("\"%s\"", path),
+			Value: fmt.Sprintf("%q", path),
 		},
 	}
 	if force {
@@ -273,7 +273,7 @@ func RemoveImport(root *dst.File, path string) *dst.ImportSpec {
 			genDecl.Tok == token.IMPORT {
 			for i, spec := range genDecl.Specs {
 				if importSpec, ok := spec.(*dst.ImportSpec); ok {
-					if importSpec.Path.Value == fmt.Sprintf("\"%s\"", path) {
+					if importSpec.Path.Value == fmt.Sprintf("%q", path) {
 						genDecl.Specs =
 							append(genDecl.Specs[:i],
 								genDecl.Specs[i+1:]...)

--- a/tool/shared/ast.go
+++ b/tool/shared/ast.go
@@ -267,7 +267,7 @@ func AddImport(root *dst.File, path string) {
 	addImport(root, path, false)
 }
 
-func RemoveImport(root *dst.File, path string) bool {
+func RemoveImport(root *dst.File, path string) *dst.ImportSpec {
 	for j, decl := range root.Decls {
 		if genDecl, ok := decl.(*dst.GenDecl); ok &&
 			genDecl.Tok == token.IMPORT {
@@ -281,13 +281,13 @@ func RemoveImport(root *dst.File, path string) bool {
 							root.Decls =
 								append(root.Decls[:j], root.Decls[j+1:]...)
 						}
-						return true
+						return importSpec
 					}
 				}
 			}
 		}
 	}
-	return false
+	return nil
 }
 
 func NewVarDecl(name string, paramTypes *dst.FieldList) *dst.GenDecl {


### PR DESCRIPTION
In hook code, if we import some package along with alias name and alias package is used within hook code, the compilation fails
```go
import (
	erralias "errors"

	"github.com/alibaba/opentelemetry-go-auto-instrumentation/pkg/api"
)

func onEnterErrorsNewAlias(call api.CallContext, text string) {
	// Check if alias name confuses compilation
	_ = erralias.ErrUnsupported
}
```
In this case, we will replace `"github.com/alibaba/opentelemetry-go-auto-instrumentation/pkg/api"` to `"errors"` and we have two `"errors"`, which finally leads to failure.