### PR TITLE
feat: coexist custom rules and default rules

### DIFF
--- a/.codeconv.yml
+++ b/.codeconv.yml
@@ -3,3 +3,5 @@ ignore:
   - "**/otel_setup.go"
 comment:                  # this is a top-level key
   layout: " diff, flags, files"
+  # Only post if coverage drops
+  require_changes: "coverage_drop"

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,17 @@
+# Copyright (c) 2024 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Get the current operating system and CPU architecture of the system
 CURRENT_OS := $(shell uname -s | tr '[:upper:]' '[:lower:]')
 CURRENT_ARCH := $(shell uname -m)

--- a/main.go
+++ b/main.go
@@ -23,12 +23,7 @@ import (
 )
 
 func main() {
-	shared.ParseOptions()
-	if shared.PrintVersion {
-		shared.PrintTheVersion()
-		os.Exit(0)
-	}
-	err := shared.InitOptions()
+	err := shared.InitConfig()
 	if err != nil {
 		log.Printf("failed to init options: %v", err)
 		os.Exit(1)

--- a/test/build_test.go
+++ b/test/build_test.go
@@ -49,10 +49,11 @@ func TestBuildProject4(t *testing.T) {
 	const AppName = "build"
 	UseApp(AppName)
 
-	RunInstrument(t, "-rule=../../pkg/data/default.json", "--", "m1")
+	RunInstrument(t, "-rule=+../../pkg/data/default.json", "--", "m1")
+	RunInstrumentFallible(t, "-rule=../../pkg/data/default.json", "--", "m1") // duplicated default rules
 	RunInstrumentFallible(t, "-rule=../../pkg/data/default", "--", "m1")
-	RunInstrument(t, "-rule=../../pkg/data/default.json,../../pkg/data/test_fmt.json", "--", "m1")
-	RunInstrument(t, "-rule=../../pkg/data/default.json,+../../pkg/data/test_fmt.json", "--", "m1")
+	RunInstrument(t, "-rule=../../pkg/data/test_error.json,../../pkg/data/test_fmt.json", "--", "m1")
+	RunInstrument(t, "-rule=../../pkg/data/test_error.json,+../../pkg/data/test_fmt.json", "--", "m1")
 	RunInstrument(t, "-rule=+../../pkg/data/default.json,+../../pkg/data/test_fmt.json", "--", "m1")
 }
 
@@ -64,7 +65,7 @@ func TestBuildProject5(t *testing.T) {
 		"-verbose", "--", "m1")
 	// both test_fmt.json and default.json rules should be available
 	// because we always append new -rule to the default.json by default
-	// (unless we use -rule=+... syntax).
-	ExpectPreprocessContains(t, shared.DebugLogFile, "fmt@@Printf")
-	ExpectPreprocessContains(t, shared.DebugLogFile, "fmt@@Printf")
+	// (unless we use -rule=+... syntax) to explicitly disable default rules.
+	ExpectPreprocessContains(t, shared.DebugLogFile, "fmt")
+	ExpectPreprocessContains(t, shared.DebugLogFile, "database/sql")
 }

--- a/test/build_test.go
+++ b/test/build_test.go
@@ -14,7 +14,11 @@
 
 package test
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/shared"
+)
 
 func TestBuildProject(t *testing.T) {
 	const AppName = "build"
@@ -48,4 +52,19 @@ func TestBuildProject4(t *testing.T) {
 	RunInstrument(t, "-rule=../../pkg/data/default.json", "--", "m1")
 	RunInstrumentFallible(t, "-rule=../../pkg/data/default", "--", "m1")
 	RunInstrument(t, "-rule=../../pkg/data/default.json,../../pkg/data/test_fmt.json", "--", "m1")
+	RunInstrument(t, "-rule=../../pkg/data/default.json,+../../pkg/data/test_fmt.json", "--", "m1")
+	RunInstrument(t, "-rule=+../../pkg/data/default.json,+../../pkg/data/test_fmt.json", "--", "m1")
+}
+
+func TestBuildProject5(t *testing.T) {
+	const AppName = "build"
+	UseApp(AppName)
+
+	RunInstrument(t, "-debuglog", "-rule=../../pkg/data/test_fmt.json",
+		"-verbose", "--", "m1")
+	// both test_fmt.json and default.json rules should be available
+	// because we always append new -rule to the default.json by default
+	// (unless we use -rule=+... syntax).
+	ExpectPreprocessContains(t, shared.DebugLogFile, "fmt@@Printf")
+	ExpectPreprocessContains(t, shared.DebugLogFile, "fmt@@Printf")
 }

--- a/test/build_test.go
+++ b/test/build_test.go
@@ -69,3 +69,16 @@ func TestBuildProject5(t *testing.T) {
 	ExpectPreprocessContains(t, shared.DebugLogFile, "fmt")
 	ExpectPreprocessContains(t, shared.DebugLogFile, "database/sql")
 }
+
+func TestBuildProject6(t *testing.T) {
+	const AppName = "build"
+	UseApp(AppName)
+
+	RunInstrument(t, "-debuglog", "-rule=+../../pkg/data/test_fmt.json",
+		"-verbose", "--", "m1")
+	// both test_fmt.json and default.json rules should be available
+	// because we always append new -rule to the default.json by default
+	// (unless we use -rule=+... syntax) to explicitly disable default rules.
+	ExpectPreprocessContains(t, shared.DebugLogFile, "fmt")
+	ExpectPreprocessNotContains(t, shared.DebugLogFile, "database/sql")
+}

--- a/test/infra.go
+++ b/test/infra.go
@@ -117,7 +117,8 @@ func RunInstrument(t *testing.T, args ...string) {
 
 func UseTestRules(name string) string {
 	path := filepath.Join(filepath.Dir(pwd), "pkg", "data", name)
-	return "-rule=" + path
+	// Only for test, so we disable default rule file and use the specified one.
+	return "-rule=+" + path
 }
 
 var pwd string

--- a/tool/build.go
+++ b/tool/build.go
@@ -15,33 +15,13 @@
 package tool
 
 import (
-	"fmt"
 	"log"
 	"os"
-	"path/filepath"
 
 	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/instrument"
 	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/preprocess"
 	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/shared"
 )
-
-func initLogs(names ...string) error {
-	for _, name := range names {
-		path := filepath.Join(shared.TempBuildDir, name)
-		err := os.MkdirAll(path, 0777)
-		if err != nil {
-			return err
-		}
-		if shared.DebugLog {
-			logPath := filepath.Join(path, shared.DebugLogFile)
-			_, err = os.Create(logPath)
-			if err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
 
 func setupLogs() {
 	if shared.InInstrument() {
@@ -49,7 +29,7 @@ func setupLogs() {
 	} else {
 		log.SetPrefix("[" + shared.TPreprocess + "] ")
 	}
-	if shared.DebugLog {
+	if shared.GetBuildConfig().DebugLog {
 		// Redirect log to debug log if required
 		debugLogPath := shared.GetLogPath(shared.DebugLogFile)
 		debugLog, _ := os.OpenFile(debugLogPath, os.O_WRONLY|os.O_APPEND, 0777)
@@ -59,41 +39,9 @@ func setupLogs() {
 	}
 }
 
-func initEnv() (err error) {
-	if shared.InInstrument() {
-		setupLogs()
-	} else {
-		// Clean up temp build directory if exists, otherwise create it
-		_, err = os.Stat(shared.TempBuildDir)
-		if err == nil {
-			err = os.RemoveAll(shared.TempBuildDir)
-			if err != nil {
-				return fmt.Errorf("failed to remove working directory: %w", err)
-			}
-		}
-		err = os.MkdirAll(shared.TempBuildDir, 0777)
-		if err != nil {
-			return fmt.Errorf("failed to make working directory: %w", err)
-		}
-
-		// @@ Init here to avoid permission issue
-		err = initLogs(shared.TPreprocess, shared.TInstrument)
-		if err != nil {
-			return fmt.Errorf("failed to init logs: %w", err)
-		}
-
-		setupLogs()
-	}
-
-	return nil
-}
-
 func Build() (err error) {
 	// Where our story begins
-	err = initEnv()
-	if err != nil {
-		return fmt.Errorf("failed to init context: %w", err)
-	}
+	setupLogs()
 	if shared.InPreprocess() {
 		return preprocess.Preprocess()
 	} else {

--- a/tool/build.go
+++ b/tool/build.go
@@ -15,33 +15,13 @@
 package tool
 
 import (
-	"log"
-	"os"
-
 	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/instrument"
 	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/preprocess"
 	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/shared"
 )
 
-func setupLogs() {
-	if shared.InInstrument() {
-		log.SetPrefix("[" + shared.TInstrument + "] ")
-	} else {
-		log.SetPrefix("[" + shared.TPreprocess + "] ")
-	}
-	if shared.GetBuildConfig().DebugLog {
-		// Redirect log to debug log if required
-		debugLogPath := shared.GetLogPath(shared.DebugLogFile)
-		debugLog, _ := os.OpenFile(debugLogPath, os.O_WRONLY|os.O_APPEND, 0777)
-		if debugLog != nil {
-			log.SetOutput(debugLog)
-		}
-	}
-}
-
 func Build() (err error) {
 	// Where our story begins
-	setupLogs()
 	if shared.InPreprocess() {
 		return preprocess.Preprocess()
 	} else {

--- a/tool/instrument/instrument.go
+++ b/tool/instrument/instrument.go
@@ -217,7 +217,7 @@ func compileRemix(bundle *resource.RuleBundle, args []string) error {
 	}
 	// Good, run final compilation after instrumentation
 	err = util.RunCmd(rp.compileArgs...)
-	if shared.Verbose {
+	if shared.GetBuildConfig().Verbose {
 		log.Printf("RunCmd: %v (%v)\n",
 			rp.compileArgs, time.Since(start))
 	} else {
@@ -231,7 +231,7 @@ func Instrument() error {
 	args := os.Args[2:]
 	// Is compile command?
 	if shared.IsCompileCommand(strings.Join(args, " ")) {
-		if shared.Verbose {
+		if shared.GetBuildConfig().Verbose {
 			log.Printf("RunCmd: %v\n", args)
 		}
 		bundles, err := resource.LoadRuleBundles()

--- a/tool/instrument/instrument.go
+++ b/tool/instrument/instrument.go
@@ -217,7 +217,7 @@ func compileRemix(bundle *resource.RuleBundle, args []string) error {
 	}
 	// Good, run final compilation after instrumentation
 	err = util.RunCmd(rp.compileArgs...)
-	if shared.GetBuildConfig().Verbose {
+	if shared.GetConf().Verbose {
 		log.Printf("RunCmd: %v (%v)\n",
 			rp.compileArgs, time.Since(start))
 	} else {
@@ -231,7 +231,7 @@ func Instrument() error {
 	args := os.Args[2:]
 	// Is compile command?
 	if shared.IsCompileCommand(strings.Join(args, " ")) {
-		if shared.GetBuildConfig().Verbose {
+		if shared.GetConf().Verbose {
 			log.Printf("RunCmd: %v\n", args)
 		}
 		bundles, err := resource.LoadRuleBundles()

--- a/tool/instrument/optimize.go
+++ b/tool/instrument/optimize.go
@@ -120,7 +120,7 @@ func (rp *RuleProcessor) removeOnExitTrampolineCall(tjump *TJump) error {
 			// Replace defer statement with an decorated empty statement to make
 			// trampoline-jump-if inlining work
 			elseBlock.List[i] = newDecoratedEmptyStmt()
-			if shared.GetBuildConfig().Verbose {
+			if shared.GetConf().Verbose {
 				log.Printf("Optimize tjump branch in %s",
 					tjump.target.Name.Name)
 			}
@@ -184,7 +184,7 @@ func (rp *RuleProcessor) removeOnEnterTrampolineCall(tjump *TJump) error {
 	tjump.ifStmt.Init = nil
 	tjump.ifStmt.Cond = shared.BoolFalse()
 	tjump.ifStmt.Body = shared.Block(newDecoratedEmptyStmt())
-	if shared.GetBuildConfig().Verbose {
+	if shared.GetConf().Verbose {
 		log.Printf("Optimize tjump branch in %s", tjump.target.Name.Name)
 	}
 	// Remove generated onEnter trampoline function
@@ -220,7 +220,7 @@ func flattenTJump(tjump *TJump, removedOnExit bool) {
 		skipCallIdent := initStmt.Lhs[1].(*dst.Ident)
 		shared.MakeUnusedIdent(skipCallIdent)
 	}
-	if shared.GetBuildConfig().Verbose {
+	if shared.GetConf().Verbose {
 		log.Printf("Optimize skipCall in %s", tjump.target.Name.Name)
 	}
 }

--- a/tool/instrument/optimize.go
+++ b/tool/instrument/optimize.go
@@ -120,7 +120,7 @@ func (rp *RuleProcessor) removeOnExitTrampolineCall(tjump *TJump) error {
 			// Replace defer statement with an decorated empty statement to make
 			// trampoline-jump-if inlining work
 			elseBlock.List[i] = newDecoratedEmptyStmt()
-			if shared.Verbose {
+			if shared.GetBuildConfig().Verbose {
 				log.Printf("Optimize tjump branch in %s",
 					tjump.target.Name.Name)
 			}
@@ -184,7 +184,7 @@ func (rp *RuleProcessor) removeOnEnterTrampolineCall(tjump *TJump) error {
 	tjump.ifStmt.Init = nil
 	tjump.ifStmt.Cond = shared.BoolFalse()
 	tjump.ifStmt.Body = shared.Block(newDecoratedEmptyStmt())
-	if shared.Verbose {
+	if shared.GetBuildConfig().Verbose {
 		log.Printf("Optimize tjump branch in %s", tjump.target.Name.Name)
 	}
 	// Remove generated onEnter trampoline function
@@ -220,7 +220,7 @@ func flattenTJump(tjump *TJump, removedOnExit bool) {
 		skipCallIdent := initStmt.Lhs[1].(*dst.Ident)
 		shared.MakeUnusedIdent(skipCallIdent)
 	}
-	if shared.Verbose {
+	if shared.GetBuildConfig().Verbose {
 		log.Printf("Optimize skipCall in %s", tjump.target.Name.Name)
 	}
 }

--- a/tool/preprocess/fetch.go
+++ b/tool/preprocess/fetch.go
@@ -98,7 +98,7 @@ func (dp *DepProcessor) fetchEmbed(path string) (string, error) {
 		if err != nil {
 			return fmt.Errorf("failed to write file: %w", err)
 		}
-		if shared.GetBuildConfig().Verbose {
+		if shared.GetConf().Verbose {
 			log.Printf("Copy embed file %v to %v", p, target)
 		}
 		return nil

--- a/tool/preprocess/fetch.go
+++ b/tool/preprocess/fetch.go
@@ -98,7 +98,7 @@ func (dp *DepProcessor) fetchEmbed(path string) (string, error) {
 		if err != nil {
 			return fmt.Errorf("failed to write file: %w", err)
 		}
-		if shared.Verbose {
+		if shared.GetBuildConfig().Verbose {
 			log.Printf("Copy embed file %v to %v", p, target)
 		}
 		return nil

--- a/tool/preprocess/match.go
+++ b/tool/preprocess/match.go
@@ -37,7 +37,7 @@ func newRuleMatcher() *ruleMatcher {
 	for _, rule := range findAvailableRules() {
 		rules[rule.GetImportPath()] = append(rules[rule.GetImportPath()], rule)
 	}
-	if shared.GetBuildConfig().Verbose {
+	if shared.GetConf().Verbose {
 		log.Printf("Available rules: %v", rules)
 	}
 	return &ruleMatcher{availableRules: rules}
@@ -101,26 +101,26 @@ func findAvailableRules() []resource.InstRule {
 	// Disable all instrumentation rules and rebuild the whole project to restore
 	// all instrumentation actions, this also reverts the modification on Golang
 	// runtime package.
-	if shared.GetBuildConfig().Restore {
+	if shared.GetConf().Restore {
 		return nil
 	}
 
 	// If rule file is not set, we will use the default rules
-	if shared.GetBuildConfig().RuleJsonFiles == "" {
+	if shared.GetConf().RuleJsonFiles == "" {
 		return loadDefaultRules()
 	}
 
 	rules := make([]resource.InstRule, 0)
 
 	// Load default rules unless explicitly disabled
-	if !shared.GetBuildConfig().IsDisableDefaultRules() {
+	if !shared.GetConf().IsDisableDefaultRules() {
 		defaultRules := loadDefaultRules()
 		rules = append(rules, defaultRules...)
 	}
 
 	// Load multiple rule files if provided
-	if strings.Contains(shared.GetBuildConfig().RuleJsonFiles, ",") {
-		ruleFiles := strings.Split(shared.GetBuildConfig().RuleJsonFiles, ",")
+	if strings.Contains(shared.GetConf().RuleJsonFiles, ",") {
+		ruleFiles := strings.Split(shared.GetConf().RuleJsonFiles, ",")
 		for _, ruleFile := range ruleFiles {
 			r, err := loadRuleFile(ruleFile)
 			if err != nil {
@@ -133,7 +133,7 @@ func findAvailableRules() []resource.InstRule {
 	}
 
 	// Load the one rule file if provided
-	rs, err := loadRuleFile(shared.GetBuildConfig().RuleJsonFiles)
+	rs, err := loadRuleFile(shared.GetConf().RuleJsonFiles)
 	if err != nil {
 		log.Printf("Failed to load rules: %v", err)
 		return nil
@@ -263,7 +263,7 @@ func runMatch(matcher *ruleMatcher, cmd string, ch chan *resource.RuleBundle) {
 	cmdArgs := shared.SplitCmds(cmd)
 	importPath := readImportPath(cmdArgs)
 	util.Assert(importPath != "", "sanity check")
-	if shared.GetBuildConfig().Verbose {
+	if shared.GetConf().Verbose {
 		log.Printf("Matching %v with %v\n", importPath, cmdArgs)
 	}
 	bundle := matcher.match(importPath, cmdArgs)

--- a/tool/preprocess/match.go
+++ b/tool/preprocess/match.go
@@ -37,7 +37,7 @@ func newRuleMatcher() *ruleMatcher {
 	for _, rule := range findAvailableRules() {
 		rules[rule.GetImportPath()] = append(rules[rule.GetImportPath()], rule)
 	}
-	if shared.Verbose {
+	if shared.GetBuildConfig().Verbose {
 		log.Printf("Available rules: %v", rules)
 	}
 	return &ruleMatcher{availableRules: rules}
@@ -87,29 +87,40 @@ func loadRuleRaw(content string) ([]resource.InstRule, error) {
 	return rules, nil
 }
 
+func loadDefaultRules() []resource.InstRule {
+	rules, err := loadRuleRaw(pkg.ExportDefaultRuleJson())
+	if err != nil {
+		log.Printf("Failed to load default rules: %v", err)
+		return nil
+	}
+	return rules
+}
+
 func findAvailableRules() []resource.InstRule {
 	shared.GuaranteeInPreprocess()
 	// Disable all instrumentation rules and rebuild the whole project to restore
 	// all instrumentation actions, this also reverts the modification on Golang
 	// runtime package.
-	if shared.Restore {
+	if shared.GetBuildConfig().Restore {
 		return nil
 	}
 
 	// If rule file is not set, we will use the default rules
-	if shared.RuleJsonFiles == "" {
-		rules, err := loadRuleRaw(pkg.ExportDefaultRuleJson())
-		if err != nil {
-			log.Printf("Failed to load default rules: %v", err)
-			return nil
-		}
-		return rules
+	if shared.GetBuildConfig().RuleJsonFiles == "" {
+		return loadDefaultRules()
 	}
 
-	// If set, check if there are multiple rule files
-	if strings.Contains(shared.RuleJsonFiles, ",") {
-		ruleFiles := strings.Split(shared.RuleJsonFiles, ",")
-		rules := make([]resource.InstRule, 0)
+	rules := make([]resource.InstRule, 0)
+
+	// Load default rules unless explicitly disabled
+	if !shared.GetBuildConfig().IsDisableDefaultRules() {
+		defaultRules := loadDefaultRules()
+		rules = append(rules, defaultRules...)
+	}
+
+	// Load multiple rule files if provided
+	if strings.Contains(shared.GetBuildConfig().RuleJsonFiles, ",") {
+		ruleFiles := strings.Split(shared.GetBuildConfig().RuleJsonFiles, ",")
 		for _, ruleFile := range ruleFiles {
 			r, err := loadRuleFile(ruleFile)
 			if err != nil {
@@ -121,12 +132,13 @@ func findAvailableRules() []resource.InstRule {
 		return rules
 	}
 
-	// Load the rule file provided by the user
-	rules, err := loadRuleFile(shared.RuleJsonFiles)
+	// Load the one rule file if provided
+	rs, err := loadRuleFile(shared.GetBuildConfig().RuleJsonFiles)
 	if err != nil {
 		log.Printf("Failed to load rules: %v", err)
 		return nil
 	}
+	rules = append(rules, rs...)
 	return rules
 }
 
@@ -251,7 +263,7 @@ func runMatch(matcher *ruleMatcher, cmd string, ch chan *resource.RuleBundle) {
 	cmdArgs := shared.SplitCmds(cmd)
 	importPath := readImportPath(cmdArgs)
 	util.Assert(importPath != "", "sanity check")
-	if shared.Verbose {
+	if shared.GetBuildConfig().Verbose {
 		log.Printf("Matching %v with %v\n", importPath, cmdArgs)
 	}
 	bundle := matcher.match(importPath, cmdArgs)

--- a/tool/preprocess/pkgdep.go
+++ b/tool/preprocess/pkgdep.go
@@ -54,7 +54,7 @@ func (dp *DepProcessor) replaceOtelImports() error {
 			if err != nil {
 				return fmt.Errorf("failed to read file content: %w", err)
 			}
-			if shared.GetBuildConfig().Verbose {
+			if shared.GetConf().Verbose {
 				log.Printf("Replace import path of %s to %s", file, moduleName)
 			}
 

--- a/tool/preprocess/pkgdep.go
+++ b/tool/preprocess/pkgdep.go
@@ -54,7 +54,7 @@ func (dp *DepProcessor) replaceOtelImports() error {
 			if err != nil {
 				return fmt.Errorf("failed to read file content: %w", err)
 			}
-			if shared.Verbose {
+			if shared.GetBuildConfig().Verbose {
 				log.Printf("Replace import path of %s to %s", file, moduleName)
 			}
 

--- a/tool/preprocess/preprocess.go
+++ b/tool/preprocess/preprocess.go
@@ -141,7 +141,7 @@ func (dp *DepProcessor) postProcess() {
 	// }
 
 	// Using -debug? Leave all changes for debugging
-	if shared.GetBuildConfig().Debug {
+	if shared.GetConf().Debug {
 		return
 	}
 
@@ -173,7 +173,7 @@ func (dp *DepProcessor) backupFile(origin string) error {
 		}
 		dp.backups[origin] = backup
 		log.Printf("Backup %v\n", origin)
-	} else if shared.GetBuildConfig().Verbose {
+	} else if shared.GetConf().Verbose {
 		log.Printf("Backup %v already exists\n", origin)
 	}
 	return nil
@@ -239,7 +239,7 @@ func (dp *DepProcessor) getImportCandidates() ([]string, error) {
 	found := false
 
 	// Find from build arguments e.g. go build test.go or go build cmd/app
-	for _, buildArg := range shared.GetBuildConfig().BuildArgs {
+	for _, buildArg := range shared.GetConf().BuildArgs {
 		// FIXME: Should we check file permission here? As we are likely to read
 		// it later, which would cause fatal error if permission is not granted.
 
@@ -312,7 +312,7 @@ func (dp *DepProcessor) addExplicitImport(importPaths ...string) (err error) {
 		// Prepend import path to the file
 		for _, importPath := range importPaths {
 			shared.AddImportForcely(astRoot, importPath)
-			if shared.GetBuildConfig().Verbose {
+			if shared.GetConf().Verbose {
 				log.Printf("Add %s import to %v", importPath, file)
 			}
 		}
@@ -368,7 +368,7 @@ func (dp *DepProcessor) findLocalImportPath() error {
 		return fmt.Errorf("failed to get module name: %w", err)
 	}
 	dp.localImportPath = strings.Replace(workingDir, projectDir, moduleName, 1)
-	if shared.GetBuildConfig().Verbose {
+	if shared.GetConf().Verbose {
 		log.Printf("Find local import path: %v", dp.localImportPath)
 	}
 	return nil
@@ -413,7 +413,7 @@ func (dp *DepProcessor) preclean() {
 			continue
 		}
 		if shared.RemoveImport(astRoot, ruleImport) != nil {
-			if shared.GetBuildConfig().Verbose {
+			if shared.GetConf().Verbose {
 				log.Printf("Remove obsolete import %v from %v",
 					ruleImport, file)
 			}
@@ -450,7 +450,7 @@ func runDryBuild() error {
 	}
 	// The full build command is: "go build -a -x -n {BuildArgs...}"
 	args := append([]string{"build", "-a", "-x", "-n"},
-		shared.GetBuildConfig().BuildArgs...)
+		shared.GetConf().BuildArgs...)
 	cmd := exec.Command("go", args...)
 	cmd.Stdout = dryRunLog
 	cmd.Stderr = dryRunLog
@@ -500,21 +500,21 @@ func runBuildWithToolexec() (string, error) {
 	// Force rebuilding
 	args = append(args, "-a")
 
-	if shared.GetBuildConfig().Debug {
+	if shared.GetConf().Debug {
 		// Disable compiler optimizations for debugging mode
 		args = append(args, "-gcflags=all=-N -l")
 	}
 
 	// Append additional build arguments provided by the user
-	args = append(args, shared.GetBuildConfig().BuildArgs...)
+	args = append(args, shared.GetConf().BuildArgs...)
 
-	if shared.GetBuildConfig().Restore {
+	if shared.GetConf().Restore {
 		// Dont generate any compiled binary when using -restore
 		args = append(args, "-o")
 		args = append(args, nullDevice())
 	}
 
-	if shared.GetBuildConfig().Verbose {
+	if shared.GetConf().Verbose {
 		log.Printf("Run go build with args %v in toolexec mode", args)
 	}
 	return util.RunCmdOutput(append([]string{"go"}, args...)...)
@@ -544,7 +544,7 @@ func (dp *DepProcessor) pinDepVersion() error {
 	for _, dep := range fixedDeps {
 		p := dep.dep
 		v := dep.version
-		if shared.GetBuildConfig().Verbose {
+		if shared.GetConf().Verbose {
 			log.Printf("Pin dependency version %v@%v", p, v)
 		}
 		err := fetchDep(p + "@" + v)

--- a/tool/preprocess/setup.go
+++ b/tool/preprocess/setup.go
@@ -78,7 +78,7 @@ func (dp *DepProcessor) copyRules(target string) (err error) {
 
 					for _, file := range files {
 						if !shared.IsGoFile(file) || shared.IsGoTestFile(file) {
-							if shared.Verbose {
+							if shared.GetBuildConfig().Verbose {
 								log.Printf("Ignore file %v\n", file)
 							}
 							continue
@@ -234,7 +234,7 @@ func (dp *DepProcessor) copyRule(path, target string,
 	if err != nil {
 		return fmt.Errorf("failed to write ast to %v: %w", target, err)
 	}
-	if shared.Verbose {
+	if shared.GetBuildConfig().Verbose {
 		log.Printf("Copy dependency %v to %v", path, target)
 	}
 	return nil

--- a/tool/preprocess/setup.go
+++ b/tool/preprocess/setup.go
@@ -78,7 +78,7 @@ func (dp *DepProcessor) copyRules(target string) (err error) {
 
 					for _, file := range files {
 						if !shared.IsGoFile(file) || shared.IsGoTestFile(file) {
-							if shared.GetBuildConfig().Verbose {
+							if shared.GetConf().Verbose {
 								log.Printf("Ignore file %v\n", file)
 							}
 							continue
@@ -234,7 +234,7 @@ func (dp *DepProcessor) copyRule(path, target string,
 	if err != nil {
 		return fmt.Errorf("failed to write ast to %v: %w", target, err)
 	}
-	if shared.GetBuildConfig().Verbose {
+	if shared.GetConf().Verbose {
 		log.Printf("Copy dependency %v to %v", path, target)
 	}
 	return nil

--- a/tool/shared/flags.go
+++ b/tool/shared/flags.go
@@ -15,11 +15,11 @@
 package shared
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/util"
@@ -30,40 +30,46 @@ const (
 	VendorDir       = "vendor"
 	BuildModeVendor = "-mod=vendor"
 	BuildModeMod    = "-mod=mod"
+	BuildConfFile   = "build_conf.json"
 )
 
-// RuleFile is the file name of the rule file.
-var RuleJsonFiles = ""
+type BuildConfig struct {
+	// RuleJsonFiles is the name of the rule file. It is used to tell instrument
+	// tool where to find the instrument rules. Multiple rules are separated by
+	// comma. e.g. -rule=rule1.json,rule2.json. By default, new rules are appended
+	// to default rules, i.e. -rule=rule1.json,rule2.json is exactly equivalent to
+	// -rule=default.json,rule1.json,rule2.json. But if you do want to replace the
+	// default rules, you can add a "+" prefix to the rule file name, e.g.
+	// -rule=+rule1.json,rule2.json. In this case, the default rules will be replaced
+	// by rule1.json, and then rule2.json will be appended to the rules.
+	RuleJsonFiles string
 
-// InToolexec true means this tool is being invoked in the go build process.
-// This flag should not be set manually by users.
-var InToolexec bool
+	// InToolexec true means this tool is being invoked in the go build process.
+	// This flag **SHOULD NOT** be set manually by users.
+	InToolexec bool
 
-// DebugLog true means debug log is enabled.
-var DebugLog = false
+	// DebugLog true means debug log is enabled.
+	DebugLog bool
 
-// Verbose true means print verbose log.
-var Verbose = true
+	// Verbose true means print verbose log.
+	Verbose bool
 
-// Debug true means debug mode.
-var Debug = false
+	// Debug true means debug mode.
+	Debug bool
 
-// Restore true means restore all instrumentations.
-var Restore = false
+	// Restore true means restore all instrumentations.
+	Restore bool
 
-// BuildArgs are the arguments to pass to the go build command.
-var BuildArgs []string
+	// BuildArgs are the arguments to pass to the go build command.
+	BuildArgs []string
 
-// Version
-var PrintVersion = false
+	// PrintVersion true means print version.
+	PrintVersion bool
 
-// The following flags should be shared across preprocess and instrument.
-const (
-	WorkingDirEnv   = "OTEL_WORKING_DIRECTORY"
-	DebugLogEnv     = "OTEL_DEBUG_TO_FILE"
-	VerboseEnv      = "OTEL_VERBOSE"
-	RuleJsonFileEnv = "OTEL_RULE_JSON_FILE"
-)
+	disableDefaultRules bool
+}
+
+var buildConf *BuildConfig
 
 // This is the version of the tool, which will be printed when the -version flag
 // is passed. This value is specified by the build system.
@@ -75,30 +81,78 @@ func PrintTheVersion() {
 	fmt.Printf("%s version %s\n", TheName, TheVersion)
 }
 
-func ParseOptions() {
-	// Parse flags from command-line arguments
-	flag.BoolVar(&InToolexec, "in-toolexec", false,
-		"Run in toolexec mode")
-	flag.BoolVar(&DebugLog, "debuglog", false,
-		"Print debug log to file")
-	flag.BoolVar(&Verbose, "verbose", false,
-		"Print verbose log")
-	flag.BoolVar(&Debug, "debug", false,
-		"Enable debug mode, leave temporary files for debugging")
-	flag.BoolVar(&Restore, "restore", false,
-		"Restore all instrumentations")
-	flag.BoolVar(&PrintVersion, "version", false,
-		"Print version")
-	flag.StringVar(&RuleJsonFiles, "rule", "",
-		"Rule file in json format. Multiple rules are separated by comma")
-	flag.Parse()
-
-	// Any non-flag command-line arguments behind "--" separator will be treated
-	// as build arguments and transparently passed to the go build command.
-	BuildArgs = flag.Args()
+func GetBuildConfig() *BuildConfig {
+	util.Assert(buildConf != nil, "build config is not initialized")
+	return buildConf
 }
 
-func SetBuildMode() error {
+func (bc *BuildConfig) IsDisableDefaultRules() bool {
+	return bc.disableDefaultRules
+}
+
+func storeBuildConfig() error {
+	util.Assert(buildConf != nil, "build config is not initialized")
+	util.Assert(InPreprocess(), "sanity check")
+
+	file := GetPreprocessLogPath(BuildConfFile)
+	bs, err := json.Marshal(buildConf)
+	if err != nil {
+		return fmt.Errorf("failed to marshal build config: %w", err)
+	}
+	_, err = util.WriteFile(file, string(bs))
+	if err != nil {
+		return fmt.Errorf("failed to write build config: %w", err)
+	}
+	return nil
+}
+
+func loadBuildConfig() (*BuildConfig, error) {
+	util.Assert(buildConf == nil, "build config is already initialized")
+
+	// Early initilaization for phase identification
+	bc := &BuildConfig{}
+	flag.BoolVar(&bc.InToolexec, "in-toolexec", false,
+		"Run in toolexec mode")
+
+	// In Preprocess phase, we parse build config from command-line arguments.
+	if !bc.InToolexec {
+		flag.BoolVar(&bc.DebugLog, "debuglog", false,
+			"Print debug log to file")
+		flag.BoolVar(&bc.Verbose, "verbose", false,
+			"Print verbose log")
+		flag.BoolVar(&bc.Debug, "debug", false,
+			"Enable debug mode, leave temporary files for debugging")
+		flag.BoolVar(&bc.Restore, "restore", false,
+			"Restore all instrumentations")
+		flag.BoolVar(&bc.PrintVersion, "version", false,
+			"Print version")
+		flag.StringVar(&bc.RuleJsonFiles, "rule", "",
+			"Rule file in json format. Multiple rules are separated by comma")
+		flag.Parse()
+
+		// Any non-flag command-line arguments behind "--" separator will be treated
+		// as build arguments and transparently passed to the go build command.
+		bc.BuildArgs = flag.Args()
+
+		// At this point, the build config is fully initialized and ready to use.
+		return bc, nil
+	} else {
+		// In Instrument phase, we should not parse the flags, instead we load
+		// the config from json file.
+		file := GetPreprocessLogPath(BuildConfFile)
+		data, err := util.ReadFile(file)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read build config: %w", err)
+		}
+		err = json.Unmarshal([]byte(data), bc)
+		if err != nil {
+			return nil, fmt.Errorf("failed to unmarshal build config: %w", err)
+		}
+		return bc, nil
+	}
+}
+
+func (bc *BuildConfig) setBuildMode() error {
 	// We can't brutely always add -mod=mod here because -mod may only be set to
 	// readonly or vendor when in workspace mode. We need to check if provided
 	// -mod is vendor or vendor directory exists, then we set -mod=mod mode.
@@ -107,18 +161,18 @@ func SetBuildMode() error {
 	// Check if -mod=vendor is set, replace it with -mod=mod
 	const buildModeVendor = "-mod=vendor"
 	const buildModePrefix = "-mod"
-	for i, arg := range BuildArgs {
+	for i, arg := range bc.BuildArgs {
 		// -mod=vendor?
 		if arg == buildModeVendor {
-			BuildArgs[i] = BuildModeMod
+			bc.BuildArgs[i] = BuildModeMod
 			return nil
 		}
 		// -mod vendor?
 		if arg == buildModePrefix {
-			if len(BuildArgs) > i+1 {
-				arg1 := BuildArgs[i+1]
+			if len(bc.BuildArgs) > i+1 {
+				arg1 := bc.BuildArgs[i+1]
 				if arg1 == "vendor" {
-					BuildArgs[i+1] = "mod"
+					bc.BuildArgs[i+1] = "mod"
 					return nil
 				}
 			}
@@ -136,47 +190,18 @@ func SetBuildMode() error {
 		return fmt.Errorf("failed to check vendor directory: %w", err)
 	}
 	if exist {
-		BuildArgs = append([]string{BuildModeMod}, BuildArgs...)
+		bc.BuildArgs = append([]string{BuildModeMod}, bc.BuildArgs...)
 	}
 	return nil
 }
 
-func passOptions() error {
-	if InInstrument() {
-		// Inherit options from environment variables
-		wd := os.Getenv(WorkingDirEnv)
-		if len(wd) == 0 {
-			return fmt.Errorf("cannot find working directory")
-		}
-
-		DebugLog, _ = strconv.ParseBool(os.Getenv(DebugLogEnv))
-		Verbose, _ = strconv.ParseBool(os.Getenv(VerboseEnv))
-		RuleJsonFiles = os.Getenv(RuleJsonFileEnv)
-	} else {
-		util.Assert(InPreprocess(), "why not otherwise")
-
-		wd, err := filepath.Abs(TempBuildDir)
-		if err != nil {
-			return fmt.Errorf("failed to get working directory: %w", err)
-		}
-		// Otherwise, set environment variables for further go toolexec build
-		err = os.Setenv(WorkingDirEnv, wd)
-		if err != nil {
-			return fmt.Errorf("failed to set working directory: %w", err)
-		}
-		err = os.Setenv(DebugLogEnv, strconv.FormatBool(DebugLog))
-		if err != nil {
-			return fmt.Errorf("failed to set debug log flag: %w", err)
-		}
-		err = os.Setenv(VerboseEnv, strconv.FormatBool(Verbose))
-		if err != nil {
-			return fmt.Errorf("failed to set use rules flag: %w", err)
-		}
+func (bc *BuildConfig) makeRuleAbs(file string) (string, error) {
+	// Check if rule json file has a "+" prefix, which means to replace the
+	// default rules, i.e. whether to keep the default rules.
+	if strings.HasPrefix(file, "+") {
+		bc.disableDefaultRules = false
+		file = file[1:]
 	}
-	return nil
-}
-
-func makeRuleAbs(file string) (string, error) {
 	exist, err := util.PathExists(file)
 	if err != nil {
 		return "", fmt.Errorf("failed to check rule file: %w", err)
@@ -188,51 +213,119 @@ func makeRuleAbs(file string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to get rule file: %w", err)
 	}
-
 	return file, nil
 }
 
-func makeRulesAbs() error {
-	if RuleJsonFiles == "" {
+func (bc *BuildConfig) parseRuleFiles() error {
+	if InInstrument() {
 		return nil
 	}
-	if strings.Contains(RuleJsonFiles, ",") {
-		files := strings.Split(RuleJsonFiles, ",")
+	// Get absolute path of rule file, otherwise instrument will not
+	// be able to find the rule file because it is running in different
+	// working directory.
+	if bc.RuleJsonFiles == "" {
+		return nil
+	}
+	if strings.Contains(bc.RuleJsonFiles, ",") {
+		files := strings.Split(bc.RuleJsonFiles, ",")
 		for i, file := range files {
-			f, err := makeRuleAbs(file)
+			f, err := bc.makeRuleAbs(file)
 			if err != nil {
 				return fmt.Errorf("failed to set rule file: %w", err)
 			}
 			files[i] = f
 		}
-		RuleJsonFiles = strings.Join(files, ",")
+		bc.RuleJsonFiles = strings.Join(files, ",")
 	} else {
-		f, err := makeRuleAbs(RuleJsonFiles)
+		f, err := bc.makeRuleAbs(bc.RuleJsonFiles)
 		if err != nil {
 			return fmt.Errorf("failed to set rule file: %w", err)
 		}
-		RuleJsonFiles = f
+		bc.RuleJsonFiles = f
 	}
 	return nil
 }
 
-func InitOptions() (err error) {
-	err = passOptions()
+func initLogs(names ...string) error {
+	for _, name := range names {
+		path := filepath.Join(TempBuildDir, name)
+		err := os.MkdirAll(path, 0777)
+		if err != nil {
+			return err
+		}
+		if GetBuildConfig().DebugLog {
+			logPath := filepath.Join(path, DebugLogFile)
+			_, err = os.Create(logPath)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func initTempDir() error {
+	// Create temp build directory in preprocess phase, this should be
+	// done in very early stage, as every further operation will likely
+	// depend on this directory.
+	if InPreprocess() {
+		// Clean up temp build directory if exists, otherwise create it
+		_, err := os.Stat(TempBuildDir)
+		if err == nil {
+			err = os.RemoveAll(TempBuildDir)
+			if err != nil {
+				return fmt.Errorf("failed to remove working directory: %w", err)
+			}
+		}
+		err = os.MkdirAll(TempBuildDir, 0777)
+		if err != nil {
+			return fmt.Errorf("failed to make working directory: %w", err)
+		}
+		// @@ Init here to avoid permission issue
+		err = initLogs(TPreprocess, TInstrument)
+		if err != nil {
+			return fmt.Errorf("failed to init logs: %w", err)
+		}
+
+	}
+	return nil
+}
+
+func InitConfig() (err error) {
+	// Load build config from either command-line arguments or json file
+	buildConf, err = loadBuildConfig()
 	if err != nil {
-		return fmt.Errorf("failed to inherit environment variables: %w", err)
+		return fmt.Errorf("failed to load build config: %w", err)
 	}
 
+	// Init temp build directory in very early stage during preprocess phase
+	err = initTempDir()
+	if err != nil {
+		return fmt.Errorf("failed to init temp dir: %w", err)
+	}
+
+	// Print version and exit early
+	if buildConf.PrintVersion {
+		PrintTheVersion()
+		os.Exit(0)
+	}
+
+	err = buildConf.parseRuleFiles()
+	if err != nil {
+		return fmt.Errorf("failed to parse rule files: %w", err)
+	}
+
+	err = buildConf.setBuildMode()
+	if err != nil {
+		return fmt.Errorf("failed to set build mode: %w", err)
+	}
+
+	// Store build config to json file for instrument phase
 	if InPreprocess() {
-		// Get absolute path of rule file, otherwise instrument will not
-		// be able to find the rule file because it is running in different
-		// working directory.
-		err = makeRulesAbs()
+		err = storeBuildConfig()
 		if err != nil {
-			return fmt.Errorf("failed to set rule file: %w", err)
-		}
-		if err = os.Setenv(RuleJsonFileEnv, RuleJsonFiles); err != nil {
-			return fmt.Errorf("failed to set rule file: %w", err)
+			return fmt.Errorf("failed to store build config: %w", err)
 		}
 	}
-	return SetBuildMode()
+	return nil
 }

--- a/tool/shared/flags.go
+++ b/tool/shared/flags.go
@@ -199,7 +199,7 @@ func (bc *BuildConfig) makeRuleAbs(file string) (string, error) {
 	// Check if rule json file has a "+" prefix, which means to replace the
 	// default rules, i.e. whether to keep the default rules.
 	if strings.HasPrefix(file, "+") {
-		bc.disableDefaultRules = false
+		bc.disableDefaultRules = true
 		file = file[1:]
 	}
 	exist, err := util.PathExists(file)

--- a/tool/shared/shared.go
+++ b/tool/shared/shared.go
@@ -65,7 +65,7 @@ func IsCompileCommand(line string) bool {
 }
 
 func GetTempBuildDir() string {
-	if GetBuildConfig().InToolexec {
+	if GetConf().InToolexec {
 		return filepath.Join(TempBuildDir, TInstrument)
 	} else {
 		return filepath.Join(TempBuildDir, TPreprocess)
@@ -192,19 +192,19 @@ func MakePublic(name string) string {
 }
 
 func InPreprocess() bool {
-	return !GetBuildConfig().InToolexec
+	return !GetConf().InToolexec
 }
 
 func InInstrument() bool {
-	return GetBuildConfig().InToolexec
+	return GetConf().InToolexec
 }
 
 func GuaranteeInPreprocess() {
-	util.Assert(!GetBuildConfig().InToolexec, "not in preprocess stage")
+	util.Assert(!GetConf().InToolexec, "not in preprocess stage")
 }
 
 func GuaranteeInInstrument() {
-	util.Assert(GetBuildConfig().InToolexec, "not in instrument stage")
+	util.Assert(GetConf().InToolexec, "not in instrument stage")
 }
 
 // splitVersionRange splits the version range into two parts, start and end.

--- a/tool/shared/shared.go
+++ b/tool/shared/shared.go
@@ -65,7 +65,7 @@ func IsCompileCommand(line string) bool {
 }
 
 func GetTempBuildDir() string {
-	if InToolexec {
+	if GetBuildConfig().InToolexec {
 		return filepath.Join(TempBuildDir, TInstrument)
 	} else {
 		return filepath.Join(TempBuildDir, TPreprocess)
@@ -192,19 +192,19 @@ func MakePublic(name string) string {
 }
 
 func InPreprocess() bool {
-	return !InToolexec
+	return !GetBuildConfig().InToolexec
 }
 
 func InInstrument() bool {
-	return InToolexec
+	return GetBuildConfig().InToolexec
 }
 
 func GuaranteeInPreprocess() {
-	util.Assert(!InToolexec, "not in preprocess stage")
+	util.Assert(!GetBuildConfig().InToolexec, "not in preprocess stage")
 }
 
 func GuaranteeInInstrument() {
-	util.Assert(InToolexec, "not in instrument stage")
+	util.Assert(GetBuildConfig().InToolexec, "not in instrument stage")
 }
 
 // splitVersionRange splits the version range into two parts, start and end.


### PR DESCRIPTION
related to #184 

RuleJsonFiles is the name of the rule file. It is used to tell instrument
tool where to find the instrument rules. Multiple rules are separated by
comma. e.g. -rule=rule1.json,rule2.json. By default, new rules are appended
to default rules, i.e. -rule=rule1.json,rule2.json is exactly equivalent to
-rule=default.json,rule1.json,rule2.json. But if you do want to replace the
default rules, you can add a "+" prefix to the rule file name, e.g.
-rule=+rule1.json,rule2.json. In this case, the default rules will be replaced
by rule1.json, and then rule2.json will be appended to the rules.