### PR TITLE
fix: make random string unique

### DIFF
--- a/tool/instrument/inst_func.go
+++ b/tool/instrument/inst_func.go
@@ -112,20 +112,8 @@ func findJumpPoint(jumpIf *dst.IfStmt) *dst.BlockStmt {
 	return nil
 }
 
-var recordedSuffixes = make(map[string]bool)
-
-func getVarSuffix() string {
-	for {
-		s := util.RandomString(5)
-		// Random suffix collision? Reroll until we get a unique one
-		if _, ok := recordedSuffixes[s]; !ok {
-			recordedSuffixes[s] = true
-			return s
-		}
-	}
-}
-
-func (rp *RuleProcessor) insertTJump(t *resource.InstFuncRule, funcDecl *dst.FuncDecl) error {
+func (rp *RuleProcessor) insertTJump(t *resource.InstFuncRule,
+	funcDecl *dst.FuncDecl) error {
 	util.Assert(t.OnEnter != "" || t.OnExit != "", "sanity check")
 
 	var retVals []dst.Expr // nil by default
@@ -164,7 +152,7 @@ func (rp *RuleProcessor) insertTJump(t *resource.InstFuncRule, funcDecl *dst.Fun
 		}
 	}
 
-	varSuffix := getVarSuffix()
+	varSuffix := util.RandomString(5)
 	rp.rule2Suffix[t] = varSuffix
 
 	// Generate the trampoline-jump-if. N.B. Note that future optimization pass

--- a/tool/preprocess/setup.go
+++ b/tool/preprocess/setup.go
@@ -263,7 +263,7 @@ func (dp *DepProcessor) initRules(pkgName, target string) (err error) {
 						if bundle.PackageName == OtelPrintStackImportPath {
 							aliasPkg = OtelPrintStackPkgAlias
 						} else {
-							aliasPkg = bundle.PackageName + util.RandomString(3)
+							aliasPkg = bundle.PackageName + util.RandomString(5)
 						}
 						imports[bundle.ImportPath] = aliasPkg
 						addedImport = true

--- a/tool/util/util.go
+++ b/tool/util/util.go
@@ -52,13 +52,23 @@ func ShouldNotReachHereT(msg string) {
 	panic("should not reach here: " + msg)
 }
 
+var recordedRand = make(map[string]bool)
+
+// RandomString generates a globally unique random string of length n
 func RandomString(n int) string {
-	var letters = []rune("0123456789")
-	b := make([]rune, n)
-	for i := range b {
-		b[i] = letters[rand.Intn(len(letters))]
+	for {
+		var letters = []rune("0123456789")
+		b := make([]rune, n)
+		for i := range b {
+			b[i] = letters[rand.Intn(len(letters))]
+		}
+		s := string(b)
+		// Random suffix collision? Reroll until we get a unique one
+		if _, ok := recordedRand[s]; !ok {
+			recordedRand[s] = true
+			return s
+		}
 	}
-	return string(b)
 }
 
 func RunCmd(args ...string) error {


### PR DESCRIPTION
Fix the following compilation error:

```
 # github.com/go-kratos/kratos/v2/transport/grpc
        [instrument] 2024/11/15 13:54:28 Apply func rule github.com/go-kratos/kratos/v2/transport/grpc@[2.5.2,2.8.3)@DialInsecure {KratosDialInsecureOnEnter KratosDialInsecureOnExit}
        [instrument] 2024/11/15 13:54:28 Apply func rule github.com/go-kratos/kratos/v2/transport/grpc@[2.5.2,2.8.3)@WithMiddleware {KratosGRPCWithMiddlewareOnEnter }
        [instrument] 2024/11/15 13:54:29 Apply func rule github.com/go-kratos/kratos/v2/transport/grpc@[2.5.2,2.8.3)@NewServer {KratosNewGRPCServiceOnEnter }
        [instrument] 2024/11/15 13:54:29 RunCmd: github.com/go-kratos/kratos/v2/transport/grpc (281.134908ms)
        # kratosTest/v2.7.2/otel_rules
        otel_rules/otel_setup_inst.go:27:8: http369 redeclared in this block
        	otel_rules/otel_setup_inst.go:13:8: other declaration of http369
        otel_rules/otel_setup_inst.go:27:8: "net/http" imported as http369 and not used
        otel_rules/otel_setup_inst.go:93:10: undefined: http369.ClientOnEnterImpl
        otel_rules/otel_setup_inst.go:94:10: undefined: http369.ClientOnExitImpl
        otel_rules/otel_setup_inst.go:97:10: undefined: http369.ServerOnEnterImpl
        otel_rules/otel_setup_inst.go:98:10: undefined: http369.ServerOnExitImpl
```