### PR TITLE
fix: api.CallContext alias conflicts with hooked package

### DIFF
--- a/pkg/rules/test/fmt7/hook.go
+++ b/pkg/rules/test/fmt7/hook.go
@@ -17,13 +17,13 @@ package fmt7
 import (
 	_ "fmt"
 
-	"github.com/alibaba/opentelemetry-go-auto-instrumentation/pkg/api"
+	aliasapi "github.com/alibaba/opentelemetry-go-auto-instrumentation/pkg/api" // both alias api and instrumented package(fmt) are imported
 )
 
-func onEnterSprintf3(call api.CallContext, format string, arg ...any) {
+func onEnterSprintf3(call aliasapi.CallContext, format string, arg ...any) {
 	println("a3")
 }
 
-func onExitSprintf3(call api.CallContext, s string) {
+func onExitSprintf3(call aliasapi.CallContext, s string) {
 	print("b3")
 }

--- a/test/helloworld_test.go
+++ b/test/helloworld_test.go
@@ -25,6 +25,7 @@ const HelloworldAppName = "helloworld"
 func TestRunHelloworld(t *testing.T) {
 	UseApp(HelloworldAppName)
 
+	RunSet(t, "-rule=")
 	RunGoBuild(t, "go", "build") // no test rules, build as usual
 	stdout, _ := RunApp(t, HelloworldAppName)
 	ExpectContains(t, stdout, "helloworld")

--- a/tool/preprocess/match.go
+++ b/tool/preprocess/match.go
@@ -106,11 +106,6 @@ func findAvailableRules() []resource.InstRule {
 		return nil
 	}
 
-	// If rule file is not set, we will use the default rules
-	if config.GetConf().RuleJsonFiles == "" {
-		return loadDefaultRules()
-	}
-
 	rules := make([]resource.InstRule, 0)
 
 	// Load default rules unless explicitly disabled
@@ -119,27 +114,29 @@ func findAvailableRules() []resource.InstRule {
 		rules = append(rules, defaultRules...)
 	}
 
-	// Load multiple rule files if provided
-	if strings.Contains(config.GetConf().RuleJsonFiles, ",") {
-		ruleFiles := strings.Split(config.GetConf().RuleJsonFiles, ",")
-		for _, ruleFile := range ruleFiles {
-			r, err := loadRuleFile(ruleFile)
-			if err != nil {
-				log.Printf("Failed to load rules: %v", err)
-				continue
+	// If rule files are provided, load them
+	if config.GetConf().RuleJsonFiles != "" {
+		// Load multiple rule files
+		if strings.Contains(config.GetConf().RuleJsonFiles, ",") {
+			ruleFiles := strings.Split(config.GetConf().RuleJsonFiles, ",")
+			for _, ruleFile := range ruleFiles {
+				r, err := loadRuleFile(ruleFile)
+				if err != nil {
+					log.Printf("Failed to load rules: %v", err)
+					continue
+				}
+				rules = append(rules, r...)
 			}
-			rules = append(rules, r...)
+			return rules
 		}
-		return rules
+		// Load the one rule file
+		rs, err := loadRuleFile(config.GetConf().RuleJsonFiles)
+		if err != nil {
+			log.Printf("Failed to load rules: %v", err)
+			return nil
+		}
+		rules = append(rules, rs...)
 	}
-
-	// Load the one rule file if provided
-	rs, err := loadRuleFile(config.GetConf().RuleJsonFiles)
-	if err != nil {
-		log.Printf("Failed to load rules: %v", err)
-		return nil
-	}
-	rules = append(rules, rs...)
 	return rules
 }
 

--- a/tool/preprocess/preprocess.go
+++ b/tool/preprocess/preprocess.go
@@ -59,7 +59,6 @@ const (
 	ReorderInitFile    = "reorder_init.go"
 	StdRulesPrefix     = "github.com/alibaba/opentelemetry-go-auto-instrumentation/pkg/"
 	StdRulesPath       = "github.com/alibaba/opentelemetry-go-auto-instrumentation/pkg/rules"
-	ApiPath            = "github.com/alibaba/opentelemetry-go-auto-instrumentation/pkg/api"
 )
 
 // @@ Change should sync with trampoline template

--- a/tool/shared/ast.go
+++ b/tool/shared/ast.go
@@ -290,6 +290,22 @@ func RemoveImport(root *dst.File, path string) *dst.ImportSpec {
 	return nil
 }
 
+func FindImport(root *dst.File, path string) *dst.ImportSpec {
+	for _, decl := range root.Decls {
+		if genDecl, ok := decl.(*dst.GenDecl); ok &&
+			genDecl.Tok == token.IMPORT {
+			for _, spec := range genDecl.Specs {
+				if importSpec, ok := spec.(*dst.ImportSpec); ok {
+					if importSpec.Path.Value == fmt.Sprintf("%q", path) {
+						return importSpec
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
 func NewVarDecl(name string, paramTypes *dst.FieldList) *dst.GenDecl {
 	return &dst.GenDecl{
 		Tok: token.VAR,


### PR DESCRIPTION
If api.CallContext has an alias, i.e. pkgapi.CallContext, while hooked package has alias name, the error happens.