### PR TITLE
fix: segfault on Takesnapshot when go build -race

### DIFF
--- a/example/extension/nethttp/README.md
+++ b/example/extension/nethttp/README.md
@@ -11,14 +11,15 @@ Replace the `Path` in `config.json` with the actual absolute path of `rules` dir
 "OnEnter":"httpClientEnterHook",
 "ReceiverType": "*Transport",
 "OnExit": "httpClientExitHook",
-"Path": "/Users/zhanghaibin/Desktop/opentelemetry-go-auto-instrumentation/example/extension/nethttp/rules"
+"Path": "/path/opentelemetry-go-auto-instrumentation/example/extension/nethttp/rules"
 }]
 ```
 
 ## Step2: Compile the target binary with otel
 Use `otel` to build the binary with `config.json`:
 ```
-cd example/extension/netHttp
+cd example/extension/nethttp
+../../../otel set -rule=config.json
 ../../../otel -rule=config.json go build demo/net_http.go
 ```
 Users can get the `otel` according to [documentation](../../../README.md)

--- a/example/extension/nethttp/config.json
+++ b/example/extension/nethttp/config.json
@@ -5,6 +5,6 @@
     "OnEnter":"httpClientEnterHook",
     "ReceiverType": "*Transport",
     "OnExit": "httpClientExitHook",
-    "Path": "/path/to/nethttp/rules"
+    "Path": "/path/opentelemetry-go-auto-instrumentation/example/extension/nethttp/rules"
   }
 ]

--- a/example/extension/sqlinject/README.md
+++ b/example/extension/sqlinject/README.md
@@ -18,7 +18,8 @@ Replace the `Path` in `config.json` with the actual absolute path of `rules` dir
 Use `otel` to build the binary with `config.json`:
 ```
 cd example/extension/sqlinject
-../../../otel -rule=config.json go build demo/sql_inject.go
+../../../otel set -rule=config.json
+../../../otel go build demo/sql_inject.go
 ```
 Users can get the `otel` according to [documentation](../../../README.md)
 

--- a/pkg/data/default.json
+++ b/pkg/data/default.json
@@ -521,7 +521,7 @@
     "Path": "github.com/alibaba/opentelemetry-go-auto-instrumentation/pkg/rules/hertz/client"
   },
   {
-    "Version": "[1.45.0,1.57.1)",
+    "Version": "[1.45.0,1.58.1)",
     "ImportPath": "github.com/valyala/fasthttp",
     "Function": "Do",
     "ReceiverType": "*HostClient",
@@ -530,7 +530,7 @@
     "Path": "github.com/alibaba/opentelemetry-go-auto-instrumentation/pkg/rules/fasthttp"
   },
   {
-    "Version": "[1.45.0,1.57.1)",
+    "Version": "[1.45.0,1.58.1)",
     "ImportPath": "github.com/valyala/fasthttp",
     "Function": "ListenAndServe",
     "ReceiverType": "*Server",

--- a/pkg/rules/otel-sdk/otel_baggage_util.go
+++ b/pkg/rules/otel-sdk/otel_baggage_util.go
@@ -18,6 +18,7 @@ type BaggageContainer struct {
 	baggage interface{}
 }
 
+//go:norace
 func (bc *BaggageContainer) TakeSnapShot() interface{} {
 	return &BaggageContainer{bc.baggage}
 }

--- a/pkg/rules/otel-sdk/trace-context/otel_trace_context.go
+++ b/pkg/rules/otel-sdk/trace-context/otel_trace_context.go
@@ -23,11 +23,9 @@ import (
 const maxSpans = 300
 
 type traceContext struct {
-	sw    *spanWrapper
-	n     int
-	DataK []string
-	DataV []interface{}
-	lcs   trace.Span
+	sw  *spanWrapper
+	n   int
+	lcs trace.Span
 }
 
 type spanWrapper struct {
@@ -94,50 +92,37 @@ func (tc *traceContext) del(span trace.Span) {
 func (tc *traceContext) clear() {
 	tc.sw = nil
 	tc.n = 0
-	tc.DataK = make([]string, 0)
-	tc.DataV = make([]interface{}, 0)
 	SetBaggageContainerToGLS(nil)
 }
 
 //go:norace
 func (tc *traceContext) TakeSnapShot() interface{} {
 	// take a deep copy to avoid reading & writing the same map at the same time
-	k := make([]string, len(tc.DataK))
-	v := make([]interface{}, len(tc.DataV))
-	copy(k, tc.DataK)
-	copy(v, tc.DataV)
 	if tc.n == 0 {
-		return &traceContext{nil, 0, k, v, nil}
+		return &traceContext{nil, 0, nil}
 	}
 	last := tc.tail()
 	sw := &spanWrapper{last, nil}
-	return &traceContext{sw, 1, k, v, nil}
+	return &traceContext{sw, 1, nil}
 }
 
 func GetGLocalData(key string) interface{} {
-	t := getOrInitTraceContext()
-	for i := 0; i < len(t.DataK); i++ {
-		if t.DataK[i] == key {
-			return t.DataV[i]
-		}
-	}
+	//todo set key into traceContext struct
+	//t := getOrInitTraceContext()
+
 	return nil
 }
 
 func SetGLocalData(key string, value interface{}) {
 	t := getOrInitTraceContext()
-	t.DataK = append(t.DataK, key)
-	t.DataV = append(t.DataV, value)
-	if len(t.DataK) != len(t.DataV) {
-		panic("DataK and DataV should have the same length")
-	}
+
 	setTraceContext(t)
 }
 
 func getOrInitTraceContext() *traceContext {
 	tc := GetTraceContextFromGLS()
 	if tc == nil {
-		newTc := &traceContext{nil, 0, nil, nil, nil}
+		newTc := &traceContext{nil, 0, nil}
 		setTraceContext(newTc)
 		return newTc
 	} else {


### PR DESCRIPTION
The crash occurs because newproc1 is executed by the m0.g0 scheduling goroutine, which lacks racectx. However, contextPropagate inserted by -race forcibly adds a call to racefuncenter(), which expects racectx to be valid. Since m0.g0.racectx is 0, this leads to a crash.

One solution is to use the Go compiler's directive:

```
//go:norace
The //go:norace directive must be followed by a function declaration. It specifies that the function's memory accesses should be ignored by the race detector. This is most commonly used in low-level code invoked at times when it is unsafe to call into the race detector runtime.
```
