### PR TITLE
feat: allow rule specifying Golang version

### DIFF
--- a/pkg/data/default.json
+++ b/pkg/data/default.json
@@ -8,7 +8,8 @@
     "ImportPath": "runtime",
     "Function":"doInit",
     "OnEnter": "reorderInitTasks(ts)",
-    "UseRaw": true
+    "UseRaw": true,
+    "GoVersion": "[1.21.0,)"
   },
   {
     "ImportPath": "runtime",

--- a/tool/util/log.go
+++ b/tool/util/log.go
@@ -17,9 +17,11 @@ package util
 import (
 	"fmt"
 	"os"
+	"sync"
 )
 
 var logWriter *os.File = os.Stdout
+var logMutex sync.Mutex
 
 var Guarantee = Assert // More meaningful name:)
 
@@ -29,7 +31,9 @@ func SetLogTo(w *os.File) {
 
 func Log(format string, args ...interface{}) {
 	template := "[" + GetRunPhase().String() + "] " + format + "\n"
+	logMutex.Lock()
 	fmt.Fprintf(logWriter, template, args...)
+	logMutex.Unlock()
 }
 
 func LogFatal(format string, args ...interface{}) {


### PR DESCRIPTION
Rule may instrument golang's standard libraries, which requires specific Go version in some rare cases, e.g.
```json
  {
    "ImportPath": "runtime",
    "Function":"doInit",
    "OnEnter": "reorderInitTasks(ts)",
    "UseRaw": true,
    "GoVersion": "[1.22.0,1.23.0)"
  },
```