### PR TITLE
fix: dont remove duplicated flags

### DIFF
--- a/test/build_test.go
+++ b/test/build_test.go
@@ -24,6 +24,7 @@ func TestBuildProject(t *testing.T) {
 	const AppName = "build"
 	UseApp(AppName)
 	RunGoBuild(t, "go", "build", "-o", "default", "cmd/foo.go")
+	RunGoBuild(t, "go", "build", "-o", "./cmd", "./cmd")
 	RunGoBuild(t, "go", "build", "cmd/foo.go")
 	RunGoBuild(t, "go", "build", "cmd/foo.go", "cmd/bar.go")
 	RunGoBuild(t, "go", "build", "cmd")

--- a/tool/preprocess/preprocess.go
+++ b/tool/preprocess/preprocess.go
@@ -458,11 +458,11 @@ func runDryBuild(goBuildCmd []string) error {
 	}
 	// The full build command is: "go build -a -x -n  {...}"
 	args := []string{"go", "build", "-a", "-x", "-n"}
-	args = append(args, goBuildCmd...)
-	args = util.StringDedup(args)
+	args = append(args, goBuildCmd[2:]...)
 	shared.AssertGoBuild(args)
 
 	// Run the dry build
+	util.Log("Run dry build %v", args)
 	cmd := exec.Command(args[0], args[1:]...)
 	cmd.Stdout = dryRunLog
 	cmd.Stderr = dryRunLog
@@ -545,7 +545,6 @@ func runBuildWithToolexec(goBuildCmd []string) error {
 	if config.GetConf().Verbose {
 		util.Log("Run go build with args %v in toolexec mode", args)
 	}
-	args = util.StringDedup(args)
 	shared.AssertGoBuild(args)
 	out, err := util.RunCmdOutput(args...)
 	util.Log("Run go build with toolexec: %v", out)

--- a/tool/util/util.go
+++ b/tool/util/util.go
@@ -300,20 +300,6 @@ func PhaseTimer(name string) func() {
 	}
 }
 
-// StringDedup removes duplicate strings in a slice and returns a new slice
-// in original order.
-func StringDedup(s []string) []string {
-	m := make(map[string]struct{})
-	var r []string
-	for _, v := range s {
-		if _, ok := m[v]; !ok {
-			m[v] = struct{}{}
-			r = append(r, v)
-		}
-	}
-	return r
-}
-
 func GetToolName() string {
 	// Get the path of the current executable
 	ex, err := os.Executable()


### PR DESCRIPTION
`go build -o ./cmd ./cmd` may fail because of duplicated `./cmd`