### PR TITLE
fix: use absolute path between Preprocess and Instrument phases

### DIFF
--- a/tool/instrument/inst_func.go
+++ b/tool/instrument/inst_func.go
@@ -65,15 +65,6 @@ func (rp *RuleProcessor) restoreAst(filePath string, root *dst.File) (string, er
 	if err != nil {
 		return "", fmt.Errorf("failed to write ast to file: %w", err)
 	}
-	// Remove old filepath from compilation files and use new file
-	// Since dry run may produce relative file path(e.g. $WORK/b012/file.go)
-	// while real compilation produce absolute file path(e.g. /tmp/b012/file.go)
-	// we need to convert the relative path to absolute path for replacement
-	// purpose.
-	filePath, err = filepath.Abs(filePath)
-	if err != nil {
-		return "", fmt.Errorf("failed to get absolute path: %w", err)
-	}
 	err = rp.replaceCompileArg(newFile, func(arg string) bool {
 		return arg == filePath
 	})
@@ -341,6 +332,7 @@ func (rp *RuleProcessor) applyFuncRules(bundle *resource.RuleBundle) (err error)
 	// Applied all matched func rules, either inserting raw code or inserting
 	// our trampoline calls.
 	for file, fn2rules := range bundle.File2FuncRules {
+		util.Assert(filepath.IsAbs(file), "file path must be absolute")
 		astRoot, err := rp.loadAst(file)
 		if err != nil {
 			return fmt.Errorf("failed to load ast from file: %w", err)

--- a/tool/instrument/inst_struct.go
+++ b/tool/instrument/inst_struct.go
@@ -16,6 +16,7 @@ package instrument
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/resource"
 	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/shared"
@@ -32,6 +33,7 @@ func addStructField(rule *resource.InstStructRule, decl dst.Decl) {
 
 func (rp *RuleProcessor) applyStructRules(bundle *resource.RuleBundle) error {
 	for file, struct2Rules := range bundle.File2StructRules {
+		util.Assert(filepath.IsAbs(file), "file path must be absolute")
 		// Apply struct rules to the file
 		astRoot, err := rp.loadAst(file)
 		if err != nil {

--- a/tool/instrument/instrument.go
+++ b/tool/instrument/instrument.go
@@ -104,6 +104,12 @@ func (rp *RuleProcessor) addCompileArg(newArg string) {
 
 func (rp *RuleProcessor) replaceCompileArg(newArg string, pred func(string) bool) error {
 	for i, arg := range rp.compileArgs {
+		// Use absolute file path of the compile argument to compare with the
+		// instrumented file(path), which is also an absolute path
+		arg, err := filepath.Abs(arg)
+		if err != nil {
+			return fmt.Errorf("failed to get absolute path: %w", err)
+		}
 		if pred(arg) {
 			rp.compileArgs[i] = newArg
 			// Relocate the replaced file to new target, any rules targeting the

--- a/tool/preprocess/match.go
+++ b/tool/preprocess/match.go
@@ -257,7 +257,11 @@ func (rm *ruleMatcher) match(cmdArgs []string) *resource.RuleBundle {
 					if rl, ok := rule.(*resource.InstStructRule); ok {
 						if shared.MatchStructDecl(genDecl, rl.StructType) {
 							util.Log("Match struct rule %s", rule)
-							bundle.AddFile2StructRule(file, rl)
+							err = bundle.AddFile2StructRule(file, rl)
+							if err != nil {
+								util.Log("Failed to add struct rule: %v", err)
+								continue
+							}
 							valid = true
 							break
 						}
@@ -267,7 +271,11 @@ func (rm *ruleMatcher) match(cmdArgs []string) *resource.RuleBundle {
 						if shared.MatchFuncDecl(funcDecl, rl.Function,
 							rl.ReceiverType) {
 							util.Log("Match func rule %s", rule)
-							bundle.AddFile2FuncRule(file, rl)
+							err = bundle.AddFile2FuncRule(file, rl)
+							if err != nil {
+								util.Log("Failed to add func rule: %v", err)
+								continue
+							}
 							valid = true
 							break
 						}

--- a/tool/resource/bundle.go
+++ b/tool/resource/bundle.go
@@ -17,6 +17,7 @@ package resource
 import (
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 
 	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/shared"
 	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/util"
@@ -58,7 +59,11 @@ func (rb *RuleBundle) IsValid() bool {
 			len(rb.File2StructRules) > 0)
 }
 
-func (rb *RuleBundle) AddFile2FuncRule(file string, rule *InstFuncRule) {
+func (rb *RuleBundle) AddFile2FuncRule(file string, rule *InstFuncRule) error {
+	file, err := filepath.Abs(file)
+	if err != nil {
+		return fmt.Errorf("failed to get abs path: %w", err)
+	}
 	fn := rule.Function + "," + rule.ReceiverType
 	util.Assert(fn != "", "sanity check")
 	if _, exist := rb.File2FuncRules[file]; !exist {
@@ -68,9 +73,14 @@ func (rb *RuleBundle) AddFile2FuncRule(file string, rule *InstFuncRule) {
 		rb.File2FuncRules[file][fn] =
 			append(rb.File2FuncRules[file][fn], rule)
 	}
+	return nil
 }
 
-func (rb *RuleBundle) AddFile2StructRule(file string, rule *InstStructRule) {
+func (rb *RuleBundle) AddFile2StructRule(file string, rule *InstStructRule) error {
+	file, err := filepath.Abs(file)
+	if err != nil {
+		return fmt.Errorf("failed to get abs path: %w", err)
+	}
 	st := rule.StructType
 	util.Assert(st != "", "sanity check")
 	if _, exist := rb.File2StructRules[file]; !exist {
@@ -80,6 +90,7 @@ func (rb *RuleBundle) AddFile2StructRule(file string, rule *InstStructRule) {
 		rb.File2StructRules[file][st] =
 			append(rb.File2StructRules[file][st], rule)
 	}
+	return nil
 }
 
 func (rb *RuleBundle) SetPackageName(name string) {


### PR DESCRIPTION
use absolute path between Preprocess and Instrument phases, otherwise compilation fails due to different source path(e.g. `./src/to/client.go` and `/root/path/src/to/client.go`)