### PR TITLE
refine: standardized error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ to engage with us.
 
 <img src="docs/dingtalk.png" height="200">
 
-## Adopters
+# Adopters
 
 These are only part of the companies using this project, for reference only. If you are using this project, please [add your company here](https://github.com/alibaba/opentelemetry-go-auto-instrumentation/issues/225) to tell us your scenario to make this project better.
 

--- a/test/build_test.go
+++ b/test/build_test.go
@@ -17,7 +17,7 @@ package test
 import (
 	"testing"
 
-	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/shared"
+	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/util"
 )
 
 func TestBuildProject(t *testing.T) {
@@ -72,8 +72,8 @@ func TestBuildProject5(t *testing.T) {
 	RunGoBuild(t, "go", "build", "m1")
 	// both test_fmt.json and default.json rules should be available
 	// because we always append new -rule to the default.json by default
-	ExpectPreprocessContains(t, shared.DebugLogFile, "fmt")
-	ExpectPreprocessContains(t, shared.DebugLogFile, "database/sql")
+	ExpectPreprocessContains(t, util.DebugLogFile, "fmt")
+	ExpectPreprocessContains(t, util.DebugLogFile, "database/sql")
 }
 
 func TestBuildProject6(t *testing.T) {
@@ -83,6 +83,6 @@ func TestBuildProject6(t *testing.T) {
 	RunSet(t, "-disabledefault=true", "-rule=../../pkg/data/test_fmt.json", "-verbose")
 	RunGoBuild(t, "go", "build", "m1")
 	// only test_fmt.json should be available because -disabledefault is set
-	ExpectPreprocessContains(t, shared.DebugLogFile, "fmt")
-	ExpectPreprocessNotContains(t, shared.DebugLogFile, "database/sql")
+	ExpectPreprocessContains(t, util.DebugLogFile, "fmt")
+	ExpectPreprocessNotContains(t, util.DebugLogFile, "database/sql")
 }

--- a/test/flags_test.go
+++ b/test/flags_test.go
@@ -17,7 +17,7 @@ package test
 import (
 	"testing"
 
-	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/shared"
+	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/util"
 )
 
 const AppName = "flags"
@@ -26,13 +26,13 @@ func TestFlags(t *testing.T) {
 	UseApp(AppName)
 
 	RunGoBuildFallible(t, "go", "build", "-thisisnotvalid")
-	ExpectPreprocessContains(t, shared.DebugLogFile, "failed to")
+	ExpectPreprocessContains(t, util.DebugLogFile, "Fatal Error")
 
 	RunVersion(t)
 	ExpectStdoutContains(t, "version")
 
 	RunGoBuildFallible(t, "go", "build", "notevenaflag")
-	ExpectPreprocessContains(t, shared.DebugLogFile, "failed to")
+	ExpectPreprocessContains(t, util.DebugLogFile, "Fatal Error")
 
 	RunSet(t, "-verbose")
 	RunGoBuild(t, "go", "build", `-ldflags=-X main.Placeholder=replaced`)
@@ -50,10 +50,10 @@ func TestFlagEnvOverwrite(t *testing.T) {
 	RunSet(t, "-verbose=false")
 	RunGoBuildWithEnv(t, []string{"OTELTOOL_VERBOSE=true"},
 		"go", "build")
-	ExpectPreprocessContains(t, shared.DebugLogFile, "Available")
+	ExpectPreprocessContains(t, util.DebugLogFile, "Available")
 
 	RunSet(t, "-verbose=true")
 	RunGoBuildWithEnv(t, []string{"OTELTOOL_VERBOSE=false"},
 		"go", "build")
-	ExpectPreprocessNotContains(t, shared.DebugLogFile, "Available")
+	ExpectPreprocessNotContains(t, util.DebugLogFile, "Available")
 }

--- a/test/infra.go
+++ b/test/infra.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/alibaba/opentelemetry-go-auto-instrumentation/test/verifier"
 	"github.com/alibaba/opentelemetry-go-auto-instrumentation/test/version"
-	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/shared"
 	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/util"
 )
 
@@ -55,7 +54,7 @@ func runCmd(args []string) *exec.Cmd {
 }
 
 func ReadInstrumentLog(t *testing.T, fileName string) string {
-	path := filepath.Join(shared.TempBuildDir, util.PInstrument, fileName)
+	path := filepath.Join(util.TempBuildDir, util.PInstrument, fileName)
 	content, err := util.ReadFile(path)
 	if err != nil {
 		t.Fatal(err)
@@ -64,7 +63,7 @@ func ReadInstrumentLog(t *testing.T, fileName string) string {
 }
 
 func ReadPreprocessLog(t *testing.T, fileName string) string {
-	path := filepath.Join(shared.TempBuildDir, util.PPreprocess, fileName)
+	path := filepath.Join(util.TempBuildDir, util.PPreprocess, fileName)
 	content, err := util.ReadFile(path)
 	if err != nil {
 		t.Fatal(err)
@@ -111,7 +110,7 @@ func RunGoBuild(t *testing.T, args ...string) {
 		t.Log(stdout)
 		t.Log("\n\n\n")
 		t.Log(stderr)
-		log1 := ReadPreprocessLog(t, shared.DebugLogFile)
+		log1 := ReadPreprocessLog(t, util.DebugLogFile)
 		text := fmt.Sprintf("failed to run instrument: %v\n", err)
 		text += fmt.Sprintf("text: %v\n", log1)
 		t.Fatal(text)
@@ -130,7 +129,7 @@ func RunGoBuildWithEnv(t *testing.T, envs []string, args ...string) {
 		t.Log(stdout)
 		t.Log("\n\n\n")
 		t.Log(stderr)
-		log1 := ReadPreprocessLog(t, shared.DebugLogFile)
+		log1 := ReadPreprocessLog(t, util.DebugLogFile)
 		text := fmt.Sprintf("failed to run instrument: %v\n", err)
 		text += fmt.Sprintf("text: %v\n", log1)
 		t.Fatal(text)
@@ -212,25 +211,25 @@ func ExpectStderrContains(t *testing.T, expect string) {
 }
 
 func ExpectInstrumentContains(t *testing.T, log string, rule string) {
-	path := filepath.Join(shared.TempBuildDir, util.PInstrument, log)
+	path := filepath.Join(util.TempBuildDir, util.PInstrument, log)
 	content := readLog(t, path)
 	ExpectContains(t, content, rule)
 }
 
 func ExpectInstrumentNotContains(t *testing.T, log string, rule string) {
-	path := filepath.Join(shared.TempBuildDir, util.PInstrument, log)
+	path := filepath.Join(util.TempBuildDir, util.PInstrument, log)
 	content := readLog(t, path)
 	ExpectNotContains(t, content, rule)
 }
 
 func ExpectPreprocessContains(t *testing.T, log string, rule string) {
-	path := filepath.Join(shared.TempBuildDir, util.PPreprocess, log)
+	path := filepath.Join(util.TempBuildDir, util.PPreprocess, log)
 	content := readLog(t, path)
 	ExpectContains(t, content, rule)
 }
 
 func ExpectPreprocessNotContains(t *testing.T, log string, rule string) {
-	path := filepath.Join(shared.TempBuildDir, util.PPreprocess, log)
+	path := filepath.Join(util.TempBuildDir, util.PPreprocess, log)
 	content := readLog(t, path)
 	ExpectNotContains(t, content, rule)
 }

--- a/test/kitex/v0.5.1/go.mod
+++ b/test/kitex/v0.5.1/go.mod
@@ -2,8 +2,6 @@ module kitex/v0.5.1
 
 go 1.22.0
 
-toolchain go1.22.7
-
 replace github.com/alibaba/opentelemetry-go-auto-instrumentation => ../../../../opentelemetry-go-auto-instrumentation
 
 replace github.com/alibaba/opentelemetry-go-auto-instrumentation/test/verifier => ../../../../opentelemetry-go-auto-instrumentation/test/verifier

--- a/test/world_test.go
+++ b/test/world_test.go
@@ -19,7 +19,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/shared"
+	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/util"
 )
 
 const WorldAppName = "world"
@@ -29,7 +29,7 @@ func TestCompileTheWorld(t *testing.T) {
 
 	RunGoBuild(t, "go", "build")
 	RunApp(t, WorldAppName)
-	text := ReadPreprocessLog(t, shared.DebugLogFile)
+	text := ReadPreprocessLog(t, util.DebugLogFile)
 
 	regex := `\"ImportPath\":\"([^"]+)\"`
 	r := regexp.MustCompile(regex)

--- a/tool/cmd/main.go
+++ b/tool/cmd/main.go
@@ -18,12 +18,13 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/config"
+	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/errc"
 	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/instrument"
 	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/preprocess"
-	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/shared"
 	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/util"
 )
 
@@ -48,17 +49,18 @@ Command:
 `
 
 func printUsage() {
-	usage = strings.ReplaceAll(usage, "{}", util.GetToolName())
+	name, _ := util.GetToolName()
+	usage = strings.ReplaceAll(usage, "{}", name)
 	fmt.Print(usage)
 }
 
 func initLog() error {
 	name := util.PPreprocess
-	path := shared.GetTempBuildDirWith(name)
-	logPath := filepath.Join(path, shared.DebugLogFile)
+	path := util.GetTempBuildDirWith(name)
+	logPath := filepath.Join(path, util.DebugLogFile)
 	_, err := os.Create(logPath)
 	if err != nil {
-		return fmt.Errorf("failed to create log file: %w", err)
+		return errc.New(errc.ErrCreateFile, err.Error())
 	}
 	return nil
 }
@@ -71,34 +73,32 @@ func initTempDir() error {
 	}
 
 	// Make temp build directory if not exists
-	if exist, _ := util.PathExists(shared.TempBuildDir); !exist {
-		err := os.MkdirAll(shared.TempBuildDir, 0777)
+	if util.PathNotExists(util.TempBuildDir) {
+		err := os.MkdirAll(util.TempBuildDir, 0777)
 		if err != nil {
-			return fmt.Errorf("failed to make working directory: %w", err)
+			return errc.New(errc.ErrMkdirAll, err.Error())
 		}
 	}
 	// Make sub-directory of temp build directory for each phase. Specifaclly,
 	// we always recreate the preprocess and instrument directories, but only
 	// create the configure directory if it does not exist. This is because
 	// the configure directory can be used across multiple runs.
-	exist, _ := util.PathExists(shared.GetTempBuildDirWith(util.PConfigure))
-	if !exist {
-		err := os.MkdirAll(shared.GetTempBuildDirWith(util.PConfigure), 0777)
+	if util.PathNotExists(util.GetTempBuildDirWith(util.PConfigure)) {
+		err := os.MkdirAll(util.GetTempBuildDirWith(util.PConfigure), 0777)
 		if err != nil {
-			return fmt.Errorf("failed to make log directory: %w", err)
+			return errc.New(errc.ErrMkdirAll, err.Error())
 		}
 	}
 	for _, subdir := range []string{util.PPreprocess, util.PInstrument} {
-		exist, _ = util.PathExists(shared.GetTempBuildDirWith(subdir))
-		if exist {
-			err := os.RemoveAll(shared.GetTempBuildDirWith(subdir))
+		if util.PathExists(util.GetTempBuildDirWith(subdir)) {
+			err := os.RemoveAll(util.GetTempBuildDirWith(subdir))
 			if err != nil {
-				return fmt.Errorf("failed to remove directory: %w", err)
+				return errc.New(errc.ErrRemoveAll, err.Error())
 			}
 		}
-		err := os.MkdirAll(shared.GetTempBuildDirWith(subdir), 0777)
+		err := os.MkdirAll(util.GetTempBuildDirWith(subdir), 0777)
 		if err != nil {
-			return fmt.Errorf("failed to make log directory: %w", err)
+			return errc.New(errc.ErrMkdirAll, err.Error())
 		}
 	}
 
@@ -126,14 +126,14 @@ func initEnv() error {
 	// Create temp build directory
 	err := initTempDir()
 	if err != nil {
-		return fmt.Errorf("failed to init temp dir: %w", err)
+		return err
 	}
 
 	// Create log files under temp build directory
 	if util.InPreprocess() {
 		err := initLog()
 		if err != nil {
-			return fmt.Errorf("failed to init logs: %w", err)
+			return err
 		}
 	}
 
@@ -141,10 +141,25 @@ func initEnv() error {
 	if util.InPreprocess() || util.InInstrument() {
 		err = config.InitConfig()
 		if err != nil {
-			return fmt.Errorf("failed to init config: %w", err)
+			return err
 		}
 	}
 	return nil
+}
+
+func fatal(err error) {
+	message := "===== Environments =====\n"
+	message += fmt.Sprintf("%-11s: %s\n", "Command", strings.Join(os.Args, " "))
+	message += fmt.Sprintf("%-11s: %s\n", "ErrorLog", util.GetLoggerPath())
+	message += fmt.Sprintf("%-11s: %s\n", "WorkDir", os.Getenv("PWD"))
+	path, _ := util.GetGoModPath()
+	message += fmt.Sprintf("%-11s: %s\n", "GoMod", path)
+	message += fmt.Sprintf("%-11s: %s, %s, %s\n", "Toolchain",
+		runtime.GOOS+"/"+runtime.GOARCH,
+		runtime.Version(), config.ToolVersion)
+	message += "===== Fatal Error ======\n"
+	message += err.Error()
+	util.LogFatal("\033[31m%s\033[0m", message) // log in red color
 }
 
 func main() {
@@ -155,8 +170,7 @@ func main() {
 
 	err := initEnv()
 	if err != nil {
-		util.LogFatal("failed to init env: %v", err)
-		os.Exit(1)
+		fatal(err)
 	}
 
 	subcmd := os.Args[1]
@@ -173,7 +187,13 @@ func main() {
 		printUsage()
 	}
 	if err != nil {
-		util.LogFatal("failed to run command %s: %v", subcmd, err)
-		os.Exit(1)
+		if subcmd != SubcommandRemix {
+			fatal(err)
+		} else {
+			// If error occurs in remix phase, we dont want to decoret the error
+			// message with the environments, just print the error message, the
+			// caller(preprocess) phase will decorate instead.
+			util.LogFatal(err.Error())
+		}
 	}
 }

--- a/tool/errc/errcode.go
+++ b/tool/errc/errcode.go
@@ -1,0 +1,114 @@
+// Copyright (c) 2025 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errc
+
+import (
+	"fmt"
+	"runtime/debug"
+)
+
+const (
+	ErrOpenFile = 1000 + iota
+	ErrCreateFile
+	ErrCloseFile
+	ErrRemoveAll
+	ErrReadDir
+	ErrCopyFile
+	ErrWriteFile
+	ErrWalkDir
+	ErrStat
+	ErrMkdirAll
+	ErrNotExist
+	ErrInvalidRule
+	ErrMatchRule
+	ErrInternal
+	ErrRunCmd
+	ErrInvalidJSON
+	ErrGetwd
+	ErrSetupRule
+	ErrParseCode
+	ErrAbsPath
+	ErrNotModularized
+	ErrGetExecutable
+	ErrInstrument
+)
+
+var errMessages = map[int]string{
+	ErrOpenFile:       "Failed to open file",
+	ErrCreateFile:     "Failed to create file",
+	ErrCloseFile:      "Failed to close file",
+	ErrRemoveAll:      "Failed to remove all files",
+	ErrReadDir:        "Failed to read directory",
+	ErrCopyFile:       "Failed to copy file",
+	ErrWriteFile:      "Failed to write file",
+	ErrWalkDir:        "Failed to walk directory",
+	ErrStat:           "Failed to get file info",
+	ErrMkdirAll:       "Failed to create directory",
+	ErrNotExist:       "File does not exist",
+	ErrInvalidRule:    "Invalid rule",
+	ErrMatchRule:      "Failed to match rule",
+	ErrInternal:       "Internal error",
+	ErrRunCmd:         "Failed to run command",
+	ErrInvalidJSON:    "Invalid JSON",
+	ErrGetwd:          "Failed to get working directory",
+	ErrSetupRule:      "Failed to setup rule",
+	ErrParseCode:      "Failed to parse Go source code",
+	ErrAbsPath:        "Failed to get absolute path",
+	ErrNotModularized: "Not a modularized project",
+	ErrGetExecutable:  "Failed to get executable",
+	ErrInstrument:     "Failed to instrument",
+}
+
+type PlentifulError struct {
+	ErrorMsg string
+	Reason   string
+	Cause    string
+	Details  map[string]string
+}
+
+func (e *PlentifulError) Error() string {
+	str := ""
+	str += fmt.Sprintf("%-11s: %v\n", "Error", e.ErrorMsg)
+	str += fmt.Sprintf("%-11s: %v\n", "Reason", e.Reason)
+	str += fmt.Sprintf("%-11s: %v\n", "Cause", e.Cause)
+	for k, v := range e.Details {
+		str += fmt.Sprintf("%-11s: %v\n", "Detail."+k, v)
+	}
+	return str
+}
+
+func New(code int, message string) *PlentifulError {
+	e := &PlentifulError{
+		ErrorMsg: errMessages[code],
+		Reason:   message,
+		Details:  make(map[string]string),
+	}
+	stackTrace := debug.Stack()
+	e.Cause = string(stackTrace)
+	return e
+}
+
+func (pe *PlentifulError) With(key, value string) *PlentifulError {
+	pe.Details[key] = value
+	return pe
+}
+
+func Adhere(err error, key, value string) error {
+	if perr, ok := err.(*PlentifulError); ok {
+		perr.Details[key] = value
+		return perr
+	}
+	return err
+}

--- a/tool/instrument/inst_func.go
+++ b/tool/instrument/inst_func.go
@@ -16,14 +16,13 @@ package instrument
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
 
+	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/errc"
 	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/resource"
-	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/shared"
 	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/util"
 	"github.com/dave/dst"
 )
@@ -47,7 +46,7 @@ func (rp *RuleProcessor) copyOtelApi(pkgName string) error {
 	target := filepath.Join(rp.workDir, OtelAPIFile)
 	file, err := resource.CopyAPITo(target, pkgName)
 	if err != nil {
-		return fmt.Errorf("failed to copy otel api: %w", err)
+		return err
 	}
 	rp.addCompileArg(file)
 	return nil
@@ -55,22 +54,23 @@ func (rp *RuleProcessor) copyOtelApi(pkgName string) error {
 
 func (rp *RuleProcessor) loadAst(filePath string) (*dst.File, error) {
 	file := rp.tryRelocated(filePath)
-	return shared.ParseAstFromFile(file)
+	return util.ParseAstFromFile(file)
 }
 
 func (rp *RuleProcessor) restoreAst(filePath string, root *dst.File) (string, error) {
 	filePath = rp.tryRelocated(filePath)
 	name := filepath.Base(filePath)
-	newFile, err := shared.WriteAstToFile(root, filepath.Join(rp.workDir, name))
+	newFile, err := util.WriteAstToFile(root, filepath.Join(rp.workDir, name))
 	if err != nil {
-		return "", fmt.Errorf("failed to write ast to file: %w", err)
+		return "", err
 	}
 	err = rp.replaceCompileArg(newFile, func(arg string) bool {
 		return arg == filePath
 	})
 	if err != nil {
-		return "", fmt.Errorf("failed to replace compile arg: %w %v %v||%v",
-			err, filePath, rp.compileArgs, os.Args)
+		err = errc.Adhere(err, "compileArgs", strings.Join(rp.compileArgs, " "))
+		err = errc.Adhere(err, "newArg", newFile)
+		return "", err
 	}
 	return newFile, nil
 }
@@ -127,10 +127,10 @@ func (rp *RuleProcessor) insertTJump(t *resource.InstFuncRule,
 	// Arguments for onEnter trampoline
 	args := make([]dst.Expr, 0)
 	// Receiver as argument for trampoline func, if any
-	if shared.HasReceiver(funcDecl) {
+	if util.HasReceiver(funcDecl) {
 		if recv := funcDecl.Recv.List; recv != nil {
 			receiver := recv[0].Names[0].Name
-			args = append(args, shared.AddressOf(shared.Ident(receiver)))
+			args = append(args, util.AddressOf(util.Ident(receiver)))
 		} else {
 			util.Unimplemented()
 		}
@@ -138,7 +138,7 @@ func (rp *RuleProcessor) insertTJump(t *resource.InstFuncRule,
 	// Original function arguments as arguments for trampoline func
 	for _, field := range funcDecl.Type.Params.List {
 		for _, name := range field.Names {
-			args = append(args, shared.AddressOf(shared.Ident(name.Name)))
+			args = append(args, util.AddressOf(util.Ident(name.Name)))
 		}
 	}
 
@@ -148,32 +148,32 @@ func (rp *RuleProcessor) insertTJump(t *resource.InstFuncRule,
 	// Generate the trampoline-jump-if. N.B. Note that future optimization pass
 	// heavily depends on the structure of trampoline-jump-if. Any change in it
 	// should be carefully examined.
-	onEnterCall := shared.CallTo(rp.makeName(t, true), args)
-	onExitCall := shared.CallTo(rp.makeName(t, false), func() []dst.Expr {
+	onEnterCall := util.CallTo(rp.makeName(t, true), args)
+	onExitCall := util.CallTo(rp.makeName(t, false), func() []dst.Expr {
 		// NB. DST framework disallows duplicated node in the
 		// AST tree, we need to replicate the return values
 		// as they are already used in return statement above
 		clone := make([]dst.Expr, len(retVals)+1)
-		clone[0] = shared.Ident(TrampolineCallContextName + varSuffix)
+		clone[0] = util.Ident(TrampolineCallContextName + varSuffix)
 		for i := 1; i < len(clone); i++ {
-			clone[i] = shared.AddressOf(retVals[i-1])
+			clone[i] = util.AddressOf(retVals[i-1])
 		}
 		return clone
 	}())
-	tjumpInit := shared.DefineStmts(
-		shared.Exprs(
-			shared.Ident(TrampolineCallContextName+varSuffix),
-			shared.Ident(TrampolineSkipName+varSuffix),
+	tjumpInit := util.DefineStmts(
+		util.Exprs(
+			util.Ident(TrampolineCallContextName+varSuffix),
+			util.Ident(TrampolineSkipName+varSuffix),
 		),
-		shared.Exprs(onEnterCall),
+		util.Exprs(onEnterCall),
 	)
-	tjumpCond := shared.Ident(TrampolineSkipName + varSuffix)
-	tjumpBody := shared.BlockStmts(
-		shared.ExprStmt(onExitCall),
-		shared.ReturnStmt(retVals),
+	tjumpCond := util.Ident(TrampolineSkipName + varSuffix)
+	tjumpBody := util.BlockStmts(
+		util.ExprStmt(onExitCall),
+		util.ReturnStmt(retVals),
 	)
-	tjumpElse := shared.Block(shared.DeferStmt(onExitCall))
-	tjump := shared.IfStmt(tjumpInit, tjumpCond, tjumpBody, tjumpElse)
+	tjumpElse := util.Block(util.DeferStmt(onExitCall))
+	tjump := util.IfStmt(tjumpInit, tjumpCond, tjumpBody, tjumpElse)
 	// Add this trampoline-jump-if as optimization candidates
 	rp.trampolineJumps = append(rp.trampolineJumps, &TJump{
 		target: funcDecl,
@@ -214,7 +214,7 @@ func (rp *RuleProcessor) insertTJump(t *resource.InstFuncRule,
 		if ifStmt, ok := firstStmt.(*dst.IfStmt); ok {
 			point := findJumpPoint(ifStmt)
 			if point != nil {
-				point.List = append(point.List, shared.EmptyStmt())
+				point.List = append(point.List, util.EmptyStmt())
 				point.List = append(point.List, tjump)
 				found = true
 			}
@@ -259,7 +259,7 @@ func (rp *RuleProcessor) insertRaw(r *resource.InstFuncRule, decl *dst.FuncDecl)
 	util.Assert(r.OnEnter != "" || r.OnExit != "", "sanity check")
 	if r.OnEnter != "" {
 		// Prepend raw code snippet to function body for onEnter
-		onEnterSnippet, err := shared.ParseAstFromSnippet(r.OnEnter)
+		onEnterSnippet, err := util.ParseAstFromSnippet(r.OnEnter)
 		if err != nil {
 			return err
 		}
@@ -267,7 +267,7 @@ func (rp *RuleProcessor) insertRaw(r *resource.InstFuncRule, decl *dst.FuncDecl)
 	}
 	if r.OnExit != "" {
 		// Use defer func(){ raw_code_snippet }() for onExit
-		onExitSnippet, err := shared.ParseAstFromSnippet(
+		onExitSnippet, err := util.ParseAstFromSnippet(
 			fmt.Sprintf("defer func(){ %s }()", r.OnExit),
 		)
 		if err != nil {
@@ -284,7 +284,7 @@ func nameReturnValues(funcDecl *dst.FuncDecl) {
 		for _, field := range funcDecl.Type.Results.List {
 			if field.Names == nil {
 				name := fmt.Sprintf("retVal%d", idx)
-				field.Names = []*dst.Ident{shared.Ident(name)}
+				field.Names = []*dst.Ident{util.Ident(name)}
 				idx++
 			}
 		}
@@ -301,15 +301,15 @@ func sortFuncRules(fnRules []*resource.InstFuncRule) []*resource.InstFuncRule {
 func (rp *RuleProcessor) writeTrampoline(pkgName string) error {
 	// Prepare trampoline code header
 	code := "package " + pkgName
-	trampoline, err := shared.ParseAstFromSource(code)
+	trampoline, err := util.ParseAstFromSource(code)
 	if err != nil {
-		return fmt.Errorf("failed to parse trampoline code header: %w", err)
+		return err
 	}
 	// One trampoline file shares common variable declarations
 	trampoline.Decls = append(trampoline.Decls, rp.varDecls...)
 	// Write trampoline code to file
 	path := filepath.Join(rp.workDir, OtelTrampolineFile)
-	trampolineFile, err := shared.WriteAstToFile(trampoline, path)
+	trampolineFile, err := util.WriteAstToFile(trampoline, path)
 	if err != nil {
 		return err
 	}
@@ -326,7 +326,7 @@ func (rp *RuleProcessor) applyFuncRules(bundle *resource.RuleBundle) (err error)
 	// Copy API file to compilation working directory
 	err = rp.copyOtelApi(bundle.PackageName)
 	if err != nil {
-		return fmt.Errorf("failed to copy otel api: %w", err)
+		return err
 	}
 
 	// Applied all matched func rules, either inserting raw code or inserting
@@ -335,7 +335,7 @@ func (rp *RuleProcessor) applyFuncRules(bundle *resource.RuleBundle) (err error)
 		util.Assert(filepath.IsAbs(file), "file path must be absolute")
 		astRoot, err := rp.loadAst(file)
 		if err != nil {
-			return fmt.Errorf("failed to load ast from file: %w", err)
+			return err
 		}
 		rp.target = astRoot
 		rp.trampolineJumps = make([]*TJump, 0)
@@ -344,7 +344,7 @@ func (rp *RuleProcessor) applyFuncRules(bundle *resource.RuleBundle) (err error)
 				nameAndRecvType := strings.Split(fnName, ",")
 				name := nameAndRecvType[0]
 				recvType := nameAndRecvType[1]
-				if shared.MatchFuncDecl(decl, name, recvType) {
+				if util.MatchFuncDecl(decl, name, recvType) {
 					fnDecl := decl.(*dst.FuncDecl)
 					// Add explicit names for return values, they can be further
 					// referenced if we're willing
@@ -359,8 +359,7 @@ func (rp *RuleProcessor) applyFuncRules(bundle *resource.RuleBundle) (err error)
 							err = rp.insertTJump(rule, fnDecl)
 						}
 						if err != nil {
-							return fmt.Errorf("failed to rewrite: %w for %v",
-								err, rule)
+							return err
 						}
 						util.Log("Apply func rule %s", rule)
 					}
@@ -371,25 +370,25 @@ func (rp *RuleProcessor) applyFuncRules(bundle *resource.RuleBundle) (err error)
 		// Optimize generated trampoline-jump-ifs
 		err = rp.optimizeTJumps()
 		if err != nil {
-			return fmt.Errorf("failed to optimize trampoline jumps: %w", err)
+			return err
 		}
 		// Restore the ast to original file once all rules are applied
 		filePath, err := rp.restoreAst(file, astRoot)
 		if err != nil {
-			return fmt.Errorf("failed to restore ast: %w", err)
+			return err
 		}
 		// Wait, all above code snippets should be inlined to new line to
 		// avoid potential misbehaviors during debugging
 		err = rp.inliningTJump(filePath)
 		if err != nil {
-			return fmt.Errorf("failed to inline trampoline call: %w", err)
+			return err
 		}
 		rp.saveDebugFile(filePath)
 	}
 
 	err = rp.writeTrampoline(bundle.PackageName)
 	if err != nil {
-		return fmt.Errorf("failed to write trampoline: %w", err)
+		return err
 	}
 	return nil
 }

--- a/tool/instrument/inst_struct.go
+++ b/tool/instrument/inst_struct.go
@@ -15,11 +15,9 @@
 package instrument
 
 import (
-	"fmt"
 	"path/filepath"
 
 	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/resource"
-	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/shared"
 	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/util"
 	"github.com/dave/dst"
 )
@@ -28,7 +26,7 @@ func addStructField(rule *resource.InstStructRule, decl dst.Decl) {
 	util.Assert(rule.FieldName != "" && rule.FieldType != "",
 		"rule must have field and type")
 	util.Log("Apply struct rule %v", rule)
-	shared.AddStructField(decl, rule.FieldName, rule.FieldType)
+	util.AddStructField(decl, rule.FieldName, rule.FieldType)
 }
 
 func (rp *RuleProcessor) applyStructRules(bundle *resource.RuleBundle) error {
@@ -37,11 +35,11 @@ func (rp *RuleProcessor) applyStructRules(bundle *resource.RuleBundle) error {
 		// Apply struct rules to the file
 		astRoot, err := rp.loadAst(file)
 		if err != nil {
-			return fmt.Errorf("failed to load ast from file: %w", err)
+			return err
 		}
 		for _, decl := range astRoot.Decls {
 			for structName, rules := range struct2Rules {
-				if shared.MatchStructDecl(decl, structName) {
+				if util.MatchStructDecl(decl, structName) {
 					for _, rule := range rules {
 						addStructField(rule, decl)
 					}
@@ -52,7 +50,7 @@ func (rp *RuleProcessor) applyStructRules(bundle *resource.RuleBundle) error {
 		// in future compilation
 		newFile, err := rp.restoreAst(file, astRoot)
 		if err != nil {
-			return fmt.Errorf("failed to restore ast: %w", err)
+			return err
 		}
 		rp.saveDebugFile(newFile)
 	}

--- a/tool/instrument/instrument.go
+++ b/tool/instrument/instrument.go
@@ -15,15 +15,14 @@
 package instrument
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/config"
+	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/errc"
 	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/resource"
-	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/shared"
 	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/util"
 	"github.com/dave/dst"
 )
@@ -108,7 +107,7 @@ func (rp *RuleProcessor) replaceCompileArg(newArg string, pred func(string) bool
 		// instrumented file(path), which is also an absolute path
 		arg, err := filepath.Abs(arg)
 		if err != nil {
-			return fmt.Errorf("failed to get absolute path: %w", err)
+			return errc.New(errc.ErrAbsPath, err.Error())
 		}
 		if pred(arg) {
 			rp.compileArgs[i] = newArg
@@ -118,7 +117,7 @@ func (rp *RuleProcessor) replaceCompileArg(newArg string, pred func(string) bool
 			return nil
 		}
 	}
-	return errors.New("no matching compile arg found")
+	return errc.New(errc.ErrInstrument, "can not innstrument the file "+newArg)
 }
 
 func (rp *RuleProcessor) saveDebugFile(path string) {
@@ -130,7 +129,7 @@ func (rp *RuleProcessor) saveDebugFile(path string) {
 	dest := filepath.Base(path)
 	util.Assert(rp.packageName != "", "sanity check")
 	dest = filepath.Join(escape(rp.packageName), dest)
-	dest = shared.GetInstrumentLogPath(dest)
+	dest = util.GetInstrumentLogPath(dest)
 	err := os.MkdirAll(filepath.Dir(dest), os.ModePerm)
 	if err != nil { // error is tolerable here
 		util.Log("failed to create debug file directory %s: %v", dest, err)
@@ -146,17 +145,20 @@ func (rp *RuleProcessor) applyRules(bundle *resource.RuleBundle) (err error) {
 	// Apply file instrument rules first
 	err = rp.applyFileRules(bundle)
 	if err != nil {
-		return fmt.Errorf("failed to apply file rules: %w", err)
+		err = errc.Adhere(err, "package", bundle.ImportPath)
+		return err
 	}
 
 	err = rp.applyStructRules(bundle)
 	if err != nil {
-		return fmt.Errorf("failed to apply struct rules: %w", err)
+		err = errc.Adhere(err, "package", bundle.ImportPath)
+		return err
 	}
 
 	err = rp.applyFuncRules(bundle)
 	if err != nil {
-		return fmt.Errorf("failed to apply function rules: %w %v", err, bundle)
+		err = errc.Adhere(err, "package", bundle.ImportPath)
+		return err
 	}
 
 	return nil
@@ -175,32 +177,41 @@ func matchImportPath(importPath string, args []string) bool {
 func guaranteeVersion(bundle *resource.RuleBundle, candidates []string) error {
 	for _, candidate := range candidates {
 		// It's not a go file, ignore silently
-		if !shared.IsGoFile(candidate) {
+		if !util.IsGoFile(candidate) {
 			continue
 		}
-		version := shared.ExtractVersion(candidate)
+		version := util.ExtractVersion(candidate)
 		for _, funcRules := range bundle.File2FuncRules {
 			for _, rules := range funcRules {
 				for _, rule := range rules {
-					matched, err := shared.MatchVersion(version, rule.GetVersion())
+					matched, err := util.MatchVersion(version, rule.GetVersion())
 					if err != nil || !matched {
-						return fmt.Errorf("failed to match version %v", err)
+						err = errc.Adhere(err, "rule", rule.String())
+						err = errc.Adhere(err, "candidate", candidate)
+						err = errc.Adhere(err, "version", version)
+						return err
 					}
 				}
 			}
 		}
 		for _, fileRule := range bundle.FileRules {
-			matched, err := shared.MatchVersion(version, fileRule.GetVersion())
+			matched, err := util.MatchVersion(version, fileRule.GetVersion())
 			if err != nil || !matched {
-				return fmt.Errorf("failed to match version %v", err)
+				err = errc.Adhere(err, "rule", fileRule.String())
+				err = errc.Adhere(err, "candidate", candidate)
+				err = errc.Adhere(err, "version", version)
+				return err
 			}
 		}
 		for _, structRules := range bundle.File2StructRules {
 			for _, rules := range structRules {
 				for _, rule := range rules {
-					matched, err := shared.MatchVersion(version, rule.GetVersion())
+					matched, err := util.MatchVersion(version, rule.GetVersion())
 					if err != nil || !matched {
-						return fmt.Errorf("failed to match version %v", err)
+						err = errc.Adhere(err, "rule", rule.String())
+						err = errc.Adhere(err, "candidate", candidate)
+						err = errc.Adhere(err, "version", version)
+						return err
 					}
 				}
 			}
@@ -217,12 +228,11 @@ func compileRemix(bundle *resource.RuleBundle, args []string) error {
 	rp := newRuleProcessor(args, bundle.PackageName)
 	err := rp.applyRules(bundle)
 	if err != nil {
-		return fmt.Errorf("failed to apply rules: %w", err)
+		return err
 	}
 	// Good, run final compilation after instrumentation
 	err = util.RunCmd(rp.compileArgs...)
-	util.Log("RunCmd: %v (%v)",
-		bundle.ImportPath, rp.compileArgs)
+	util.Log("RunCmd: %v (%v)", bundle.ImportPath, rp.compileArgs)
 	return err
 }
 
@@ -230,20 +240,27 @@ func Instrument() error {
 	// Remove the tool itself from the command line arguments
 	args := os.Args[2:]
 	// Is compile command?
-	if shared.IsCompileCommand(strings.Join(args, " ")) {
+	if util.IsCompileCommand(strings.Join(args, " ")) {
 		if config.GetConf().Verbose {
 			util.Log("RunCmd: %v", args)
 		}
 		bundles, err := resource.LoadRuleBundles()
 		if err != nil {
-			return fmt.Errorf("failed to load rule bundles: %w", err)
+			err = errc.Adhere(err, "cmd", fmt.Sprintf("%v", args))
+			return err
 		}
 		for _, bundle := range bundles {
 			util.Assert(bundle.IsValid(), "sanity check")
 			// Is compiling the target package?
 			if matchImportPath(bundle.ImportPath, args) {
 				util.Log("Apply bundle %v", bundle)
-				return compileRemix(bundle, args)
+				err = compileRemix(bundle, args)
+				if err != nil {
+					err = errc.Adhere(err, "cmd", fmt.Sprintf("%v", args))
+					err = errc.Adhere(err, "bundle", bundle.String())
+					return err
+				}
+				return nil
 			}
 		}
 	}

--- a/tool/instrument/optimize.go
+++ b/tool/instrument/optimize.go
@@ -19,8 +19,8 @@ import (
 	"strings"
 
 	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/config"
+	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/errc"
 	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/resource"
-	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/shared"
 	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/util"
 	"github.com/dave/dst"
 )
@@ -100,7 +100,7 @@ type TJump struct {
 }
 
 func newDecoratedEmptyStmt() *dst.EmptyStmt {
-	emptyStmt := shared.EmptyStmt()
+	emptyStmt := util.EmptyStmt()
 	emptyStmt.Decorations().Start.Append(TrampolineNoNewlinePlaceholder)
 	emptyStmt.Decorations().End.Append(TrampolineSemicolonPlaceholder)
 	return emptyStmt
@@ -139,7 +139,7 @@ func replenishCallContextLiteral(tjump *TJump, expr dst.Expr) {
 	rawFunc := tjump.target
 	names := make([]dst.Expr, 0)
 	for _, name := range getNames(rawFunc.Type.Params) {
-		names = append(names, shared.AddressOf(shared.Ident(name)))
+		names = append(names, util.AddressOf(util.Ident(name)))
 	}
 	elems := expr.(*dst.UnaryExpr).X.(*dst.CompositeLit).Elts
 	paramLiteral := elems[0].(*dst.KeyValueExpr).Value.(*dst.CompositeLit)
@@ -150,9 +150,9 @@ func (rp *RuleProcessor) newCallContextImpl(tjump *TJump) (dst.Expr, error) {
 	// One line please, otherwise debugging line number will be a nightmare
 	tmpl := fmt.Sprintf("&CallContextImpl%s{Params:[]interface{}{},ReturnVals:[]interface{}{}}",
 		rp.rule2Suffix[tjump.rule])
-	astRoot, err := shared.ParseAstFromSnippet(tmpl)
+	astRoot, err := util.ParseAstFromSnippet(tmpl)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse new CallContext: %w", err)
+		return nil, err
 	}
 	ctxExpr := astRoot[0].(*dst.ExprStmt).X
 	// Replenish call context by passing addresses of all arguments
@@ -164,7 +164,7 @@ func (rp *RuleProcessor) removeOnEnterTrampolineCall(tjump *TJump) error {
 	// Construct CallContext on the fly and pass to onExit trampoline defer call
 	callContextExpr, err := rp.newCallContextImpl(tjump)
 	if err != nil {
-		return fmt.Errorf("failed to construct CallContext: %w", err)
+		return err
 	}
 	// Find defer call to onExit and replace its call context with new one
 	found := false
@@ -182,8 +182,8 @@ func (rp *RuleProcessor) removeOnEnterTrampolineCall(tjump *TJump) error {
 	// Rewrite condition of trampoline-jump-if to always false and null out its
 	// initialization statement and then block
 	tjump.ifStmt.Init = nil
-	tjump.ifStmt.Cond = shared.BoolFalse()
-	tjump.ifStmt.Body = shared.Block(newDecoratedEmptyStmt())
+	tjump.ifStmt.Cond = util.BoolFalse()
+	tjump.ifStmt.Body = util.Block(newDecoratedEmptyStmt())
 	if config.GetConf().Verbose {
 		util.Log("Optimize tjump branch in %s", tjump.target.Name.Name)
 	}
@@ -196,7 +196,7 @@ func (rp *RuleProcessor) removeOnEnterTrampolineCall(tjump *TJump) error {
 		return false
 	})
 	if removed == nil {
-		return fmt.Errorf("failed to remove onEnter trampoline function")
+		return errc.New(errc.ErrInternal, "onEnter trampoline not found")
 	}
 	return nil
 }
@@ -206,19 +206,19 @@ func flattenTJump(tjump *TJump, removedOnExit bool) {
 	initStmt := ifStmt.Init.(*dst.AssignStmt)
 	util.Assert(len(initStmt.Lhs) == 2, "must be")
 
-	ifStmt.Cond = shared.BoolFalse()
-	ifStmt.Body = shared.Block(newDecoratedEmptyStmt())
+	ifStmt.Cond = util.BoolFalse()
+	ifStmt.Body = util.Block(newDecoratedEmptyStmt())
 
 	if removedOnExit {
 		// We removed the last reference to call context after nulling out body
 		// block, at this point, all lhs are unused, replace assignment to simple
 		// function call
-		ifStmt.Init = shared.ExprStmt(initStmt.Rhs[0])
+		ifStmt.Init = util.ExprStmt(initStmt.Rhs[0])
 		// TODO: Remove onExit declaration
 	} else {
 		// Otherwise, mark skipCall identifier as unused
 		skipCallIdent := initStmt.Lhs[1].(*dst.Ident)
-		shared.MakeUnusedIdent(skipCallIdent)
+		util.MakeUnusedIdent(skipCallIdent)
 	}
 	if config.GetConf().Verbose {
 		util.Log("Optimize skipCall in %s", tjump.target.Name.Name)
@@ -239,7 +239,7 @@ func (rp *RuleProcessor) optimizeTJumps() (err error) {
 		if rule.OnExit == "" {
 			err = rp.removeOnExitTrampolineCall(tjump)
 			if err != nil {
-				return fmt.Errorf("failed to optimize tjump: %w", err)
+				return err
 			}
 			removedOnExit = true
 		}
@@ -249,7 +249,7 @@ func (rp *RuleProcessor) optimizeTJumps() (err error) {
 		if rule.OnEnter == "" {
 			err = rp.removeOnEnterTrampolineCall(tjump)
 			if err != nil {
-				return fmt.Errorf("failed to optimize tjump: %w", err)
+				return err
 			}
 		}
 
@@ -261,7 +261,7 @@ func (rp *RuleProcessor) optimizeTJumps() (err error) {
 		if rule.OnEnter != "" {
 			onEnterHook, err := getHookFunc(rule, true)
 			if err != nil {
-				return fmt.Errorf("failed to get hook: %w", err)
+				return err
 			}
 			foundPoison := false
 			const poison = "SkipCall"

--- a/tool/preprocess/pkgdep.go
+++ b/tool/preprocess/pkgdep.go
@@ -14,11 +14,9 @@
 package preprocess
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/resource"
-	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/shared"
 	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/util"
 )
 
@@ -35,28 +33,28 @@ func replaceImport(importPath string, code string) string {
 func (dp *DepProcessor) replaceOtelImports() error {
 	moduleName, err := dp.getImportPathOf(OtelPkgDep)
 	if err != nil {
-		return fmt.Errorf("failed to get import path of otel_pkg: %w", err)
+		return err
 	}
 
 	for _, dep := range []string{OtelRules, OtelPkgDep} {
 		files, err := util.ListFiles(dep)
 		if err != nil {
-			return fmt.Errorf("failed to list files: %w", err)
+			return err
 		}
 		for _, file := range files {
 			// Skip non-go files as no imports within them
-			if !shared.IsGoFile(file) {
+			if !util.IsGoFile(file) {
 				continue
 			}
 			// Read file content and replace content then write back
 			content, err := util.ReadFile(file)
 			if err != nil {
-				return fmt.Errorf("failed to read file content: %w", err)
+				return err
 			}
 			content = replaceImport(moduleName, content)
 			_, err = util.WriteFile(file, content)
 			if err != nil {
-				return fmt.Errorf("failed to write file content: %w", err)
+				return err
 			}
 		}
 	}
@@ -64,9 +62,5 @@ func (dp *DepProcessor) replaceOtelImports() error {
 }
 
 func (dp *DepProcessor) copyPkgDep() error {
-	err := resource.CopyPkgTo(OtelPkgDep)
-	if err != nil {
-		return fmt.Errorf("failed to copy pkg deps: %w", err)
-	}
-	return nil
+	return resource.CopyPkgTo(OtelPkgDep)
 }

--- a/tool/preprocess/setup.go
+++ b/tool/preprocess/setup.go
@@ -22,8 +22,8 @@ import (
 	"strings"
 
 	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/config"
+	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/errc"
 	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/resource"
-	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/shared"
 	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/util"
 	"github.com/dave/dst"
 )
@@ -35,15 +35,15 @@ const (
 )
 
 func initRuleDir() (err error) {
-	if exist, _ := util.PathExists(OtelRules); exist {
+	if util.PathExists(OtelRules) {
 		err = os.RemoveAll(OtelRules)
 		if err != nil {
-			return fmt.Errorf("failed to remove dir %v: %w", OtelRules, err)
+			return errc.New(errc.ErrRemoveAll, OtelRules)
 		}
 	}
 	err = os.MkdirAll(OtelRules, os.ModePerm)
 	if err != nil {
-		return fmt.Errorf("failed to create dir %v: %w", OtelRules, err)
+		return errc.New(errc.ErrMkdirAll, OtelRules)
 	}
 	return nil
 }
@@ -70,7 +70,7 @@ func (dp *DepProcessor) copyRules(pkgName string) (err error) {
 						return err
 					}
 					if len(files) == 0 {
-						return fmt.Errorf("can not find resource for %v", rule)
+						return errc.New(errc.ErrInvalidRule, rule.String())
 					}
 					// Although different rule hooks may instrument the same
 					// function, we still need to create separate directories
@@ -81,21 +81,19 @@ func (dp *DepProcessor) copyRules(pkgName string) (err error) {
 					dp.rule2Dir[rule] = dir
 
 					for _, file := range files {
-						if !shared.IsGoFile(file) || shared.IsGoTestFile(file) {
+						if !util.IsGoFile(file) || util.IsGoTestFile(file) {
 							continue
 						}
 
 						ruleDir := filepath.Join(pkgName, dir)
 						err = os.MkdirAll(ruleDir, 0777)
 						if err != nil {
-							return fmt.Errorf("failed to create dir %v: %w",
-								ruleDir, err)
+							return errc.New(errc.ErrMkdirAll, err.Error())
 						}
 						ruleFile := filepath.Join(ruleDir, filepath.Base(file))
 						err = dp.copyRule(file, ruleFile, bundle)
 						if err != nil {
-							return fmt.Errorf("failed to copy rule %v: %w",
-								file, err)
+							return err
 						}
 					}
 				}
@@ -105,6 +103,7 @@ func (dp *DepProcessor) copyRules(pkgName string) (err error) {
 
 	return nil
 }
+
 func rectifyCallContext(astRoot *dst.File, bundle *resource.RuleBundle) {
 	// We write hook code by using api.CallContext as the first parameter, but
 	// the actual package name is not api. Given net/http package, the actual
@@ -115,7 +114,7 @@ func rectifyCallContext(astRoot *dst.File, bundle *resource.RuleBundle) {
 	// omit the package name before, but we can't do that now because of renaming
 	newAliasName := bundle.PackageName + util.RandomString(5)
 	alias := ApiPackage
-	spec := shared.FindImport(astRoot, ApiImportPath)
+	spec := util.FindImport(astRoot, ApiImportPath)
 	if spec != nil {
 		if spec.Name != nil {
 			alias = spec.Name.Name
@@ -146,6 +145,7 @@ func rectifyCallContext(astRoot *dst.File, bundle *resource.RuleBundle) {
 		}
 	}
 }
+
 func makeHookPublic(astRoot *dst.File, bundle *resource.RuleBundle) {
 	// Only make hook public, keep it as it is if it's not a hook
 	hooks := make(map[string]bool)
@@ -181,12 +181,12 @@ func (dp *DepProcessor) copyRule(path, target string,
 	bundle *resource.RuleBundle) error {
 	text, err := util.ReadFile(path)
 	if err != nil {
-		return fmt.Errorf("failed to read rule file %v: %w", path, err)
+		return err
 	}
-	text = shared.RemoveGoBuildComment(text)
-	astRoot, err := shared.ParseAstFromSource(text)
+	text = util.RemoveGoBuildComment(text)
+	astRoot, err := util.ParseAstFromSource(text)
 	if err != nil {
-		return fmt.Errorf("failed to parse ast from source: %w", err)
+		return err
 	}
 	// Rename package name nevertheless
 	astRoot.Name.Name = filepath.Base(filepath.Dir(target))
@@ -198,9 +198,9 @@ func (dp *DepProcessor) copyRule(path, target string,
 	makeHookPublic(astRoot, bundle)
 
 	// Copy used rule into project
-	_, err = shared.WriteAstToFile(astRoot, target)
+	_, err = util.WriteAstToFile(astRoot, target)
 	if err != nil {
-		return fmt.Errorf("failed to write ast to %v: %w", target, err)
+		return err
 	}
 	if config.GetConf().Verbose {
 		util.Log("Copy dependency %v to %v", path, target)
@@ -245,16 +245,15 @@ func (dp *DepProcessor) initRules(pkgName string) (err error) {
 						rd := fmt.Sprintf("%s/%s", OtelRules, dp.rule2Dir[rule])
 						path, err := dp.getImportPathOf(rd)
 						if err != nil {
-							return fmt.Errorf("failed to get import path: %w",
-								err)
+							return err
 						}
 						imports[path] = dp.rule2Dir[rule]
 						assigns = append(assigns,
 							fmt.Sprintf("\t%s.%s = %s.%s\n",
 								aliasPkg,
-								shared.GetVarNameOfFunc(rule.OnEnter),
+								util.GetVarNameOfFunc(rule.OnEnter),
 								dp.rule2Dir[rule],
-								shared.MakePublic(rule.OnEnter),
+								util.MakePublic(rule.OnEnter),
 							),
 						)
 					}
@@ -262,17 +261,16 @@ func (dp *DepProcessor) initRules(pkgName string) (err error) {
 						rd := fmt.Sprintf("%s/%s", OtelRules, dp.rule2Dir[rule])
 						path, err := dp.getImportPathOf(rd)
 						if err != nil {
-							return fmt.Errorf("failed to get import path: %w",
-								err)
+							return err
 						}
 						imports[path] = dp.rule2Dir[rule]
 						assigns = append(assigns,
 							fmt.Sprintf(
 								"\t%s.%s = %s.%s\n",
 								aliasPkg,
-								shared.GetVarNameOfFunc(rule.OnExit),
+								util.GetVarNameOfFunc(rule.OnExit),
 								dp.rule2Dir[rule],
-								shared.MakePublic(rule.OnExit),
+								util.MakePublic(rule.OnExit),
 							),
 						)
 					}
@@ -320,11 +318,11 @@ func (dp *DepProcessor) initRules(pkgName string) (err error) {
 func (dp *DepProcessor) addRuleImport() error {
 	ruleImportPath, err := dp.getImportPathOf(OtelRules)
 	if err != nil {
-		return fmt.Errorf("failed to get import path: %w", err)
+		return err
 	}
 	err = dp.addExplicitImport(ruleImportPath)
 	if err != nil {
-		return fmt.Errorf("failed to add rule import: %w", err)
+		return err
 	}
 	return nil
 }
@@ -346,9 +344,9 @@ func (dp *DepProcessor) rewriteRules() error {
 			if !strings.HasSuffix(rule.FileName, ReorderInitFile) {
 				continue
 			}
-			astRoot, err := shared.ParseAstFromFile(rule.FileName)
+			astRoot, err := util.ParseAstFromFile(rule.FileName)
 			if err != nil {
-				return fmt.Errorf("failed to parse ast from source: %w", err)
+				return err
 			}
 			found := false
 			dst.Inspect(astRoot, func(n dst.Node) bool {
@@ -356,7 +354,7 @@ func (dp *DepProcessor) rewriteRules() error {
 					if basicLit.Kind == token.STRING {
 						quoted := fmt.Sprintf("%q", ReorderLocalPrefix)
 						if basicLit.Value == quoted {
-							gomod, err := shared.GetGoModPath()
+							gomod, err := util.GetGoModPath()
 							if err != nil {
 								return false
 							}
@@ -373,13 +371,11 @@ func (dp *DepProcessor) rewriteRules() error {
 				return true
 			})
 			if !found {
-				return fmt.Errorf("failed to find rewrite local prefix in %v",
-					rule.FileName)
+				return errc.New(errc.ErrInternal, "no localPrefix found")
 			} else {
-				_, err = shared.WriteAstToFile(astRoot, rule.FileName)
+				_, err = util.WriteAstToFile(astRoot, rule.FileName)
 				if err != nil {
-					return fmt.Errorf("failed to write ast to %v: %w",
-						rule.FileName, err)
+					return err
 				}
 			}
 		}
@@ -391,37 +387,37 @@ func (dp *DepProcessor) setupOtelSDK(pkgName string) error {
 	setupTarget := filepath.Join(OtelRules, OtelSetupSDK)
 	_, err := resource.CopyOtelSetupTo(pkgName, setupTarget)
 	if err != nil {
-		return fmt.Errorf("failed to copy otel setup sdk: %w", err)
+		return err
 	}
-	return err
+	return nil
 }
 
 func (dp *DepProcessor) setupRules() (err error) {
 	defer util.PhaseTimer("Setup")()
 	err = initRuleDir()
 	if err != nil {
-		return fmt.Errorf("failed to create directory: %w", err)
+		return err
 	}
 	err = dp.copyRules(OtelRules)
 	if err != nil {
-		return fmt.Errorf("failed to setup rules: %w", err)
+		return err
 	}
 	err = dp.initRules(OtelRules)
 	if err != nil {
-		return fmt.Errorf("failed to setup initiator: %w", err)
+		return err
 	}
 	err = dp.rewriteRules()
 	if err != nil {
-		return fmt.Errorf("failed to rewrite rules: %w", err)
+		return err
 	}
 	err = dp.setupOtelSDK(OtelRules)
 	if err != nil {
-		return fmt.Errorf("failed to setup otel sdk: %w", err)
+		return err
 	}
 	// Add rule import to all candidates
 	err = dp.addRuleImport()
 	if err != nil {
-		return fmt.Errorf("failed to add rule import: %w", err)
+		return err
 	}
 	return nil
 }

--- a/tool/resource/resource.go
+++ b/tool/resource/resource.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 
 	"github.com/alibaba/opentelemetry-go-auto-instrumentation/pkg"
-	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/shared"
 	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/util"
 )
 
@@ -84,7 +83,7 @@ func CopyOtelSetupTo(pkgName, target string) (string, error) {
 	template := pkg.ExportOtelSetupSDKTemplate()
 	snippet := strings.Replace(template,
 		"package pkg", "package "+pkgName, 1)
-	snippet = shared.RemoveGoBuildComment(snippet)
+	snippet = util.RemoveGoBuildComment(snippet)
 	return util.WriteFile(target, snippet)
 }
 

--- a/tool/resource/ruledef.go
+++ b/tool/resource/ruledef.go
@@ -15,10 +15,10 @@ package resource
 
 import (
 	"encoding/json"
-	"fmt"
 	"strings"
 
-	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/shared"
+	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/errc"
+	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/util"
 )
 
 // -----------------------------------------------------------------------------
@@ -135,12 +135,12 @@ func (rule *InstFileRule) String() string {
 func verifyRule(rule *InstBaseRule, checkPath bool) error {
 	if checkPath {
 		if rule.Path == "" {
-			return fmt.Errorf("local path is empty")
+			return errc.New(errc.ErrInvalidRule, "local path is empty")
 		}
 	}
 	// Import path should not be empty
 	if rule.ImportPath == "" {
-		return fmt.Errorf("import path is empty")
+		return errc.New(errc.ErrInvalidRule, "import path is empty")
 	}
 	// If version is specified, it should be in the format of [start,end)
 	for _, v := range []string{rule.Version, rule.GoVersion} {
@@ -149,7 +149,7 @@ func verifyRule(rule *InstBaseRule, checkPath bool) error {
 				!strings.Contains(v, ")") ||
 				!strings.Contains(v, ",") ||
 				strings.Contains(v, "v") {
-				return fmt.Errorf("invalid version format %s", v)
+				return errc.New(errc.ErrInvalidRule, "bad version "+v)
 			}
 		}
 	}
@@ -170,10 +170,10 @@ func (rule *InstFileRule) Verify() error {
 		return err
 	}
 	if rule.FileName == "" {
-		return fmt.Errorf("file name is empty")
+		return errc.New(errc.ErrInvalidRule, "empty file name")
 	}
-	if !shared.IsGoFile(rule.FileName) {
-		return fmt.Errorf("file name should not end with .go")
+	if !util.IsGoFile(rule.FileName) {
+		return errc.New(errc.ErrInvalidRule, "not a go file")
 	}
 	return nil
 }
@@ -189,10 +189,10 @@ func (rule *InstFuncRule) Verify() error {
 		return err
 	}
 	if rule.Function == "" {
-		return fmt.Errorf("function name is empty")
+		return errc.New(errc.ErrInvalidRule, "empty function name")
 	}
 	if rule.OnEnter == "" && rule.OnExit == "" {
-		return fmt.Errorf("both onEnter and onExit are empty")
+		return errc.New(errc.ErrInvalidRule, "empty hook")
 	}
 	return nil
 }
@@ -203,10 +203,10 @@ func (rule *InstStructRule) Verify() error {
 		return err
 	}
 	if rule.StructType == "" {
-		return fmt.Errorf("struct type is empty")
+		return errc.New(errc.ErrInvalidRule, "empty struct type")
 	}
 	if rule.FieldName == "" || rule.FieldType == "" {
-		return fmt.Errorf("field name is empty")
+		return errc.New(errc.ErrInvalidRule, "empty field name or type")
 	}
 	return nil
 }

--- a/tool/util/log.go
+++ b/tool/util/log.go
@@ -25,8 +25,13 @@ var logMutex sync.Mutex
 
 var Guarantee = Assert // More meaningful name:)
 
-func SetLogTo(w *os.File) {
+// Be caution it's not thread safe
+func SetLogger(w *os.File) {
 	logWriter = w
+}
+
+func GetLoggerPath() string {
+	return logWriter.Name()
 }
 
 func Log(format string, args ...interface{}) {
@@ -37,13 +42,9 @@ func Log(format string, args ...interface{}) {
 }
 
 func LogFatal(format string, args ...interface{}) {
-	// Log errors to debug file
 	Log(format, args...)
-	// And print to stderr then, in red color
-	template := "Build error:\033[31m\n" + format + "\033[0m\n"
-	fmt.Fprintf(os.Stderr, template,
-		args...)
-	fmt.Fprintf(os.Stderr, "See build log %s for details.\n",
-		logWriter.Name())
+	if InPreprocess() {
+		fmt.Fprintf(os.Stderr, format, args...)
+	}
 	os.Exit(1)
 }


### PR DESCRIPTION
related to #267 

standardize error message, something like bellow

```
Command    : ../../otel go build xxx
ErrorLog   : .otel-build/preprocess/debug.log
WorkDir    : /home/yyang/opentelemetry-go-auto-instrumentation/test/helloworld
GoMod      : /home/yyang/opentelemetry-go-auto-instrumentation/test/helloworld/go.mod
GoVersion  : go1.22.0
ToolVersion: 0.4.0_8a27e33
OS         : linux/amd64
Code       : 1014
Message    : exit status 1
Cause      : goroutine 1 [running]:
runtime/debug.Stack()
        /usr/local/go/src/runtime/debug/stack.go:24 +0x5e
github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/errc.New(0x3f6, {0xc000013160, 0xd})
        /home/yyang/opentelemetry-go-auto-instrumentation/tool/errc/errcode.go:57 +0x88
github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/preprocess.runDryBuild({0xc0004136b0, 0x3, 0x3})
        /home/yyang/opentelemetry-go-auto-instrumentation/tool/preprocess/preprocess.go:475 +0x2a5
github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/preprocess.(*DepProcessor).setupDeps(0xc00041c280)
        /home/yyang/opentelemetry-go-auto-instrumentation/tool/preprocess/preprocess.go:696 +0x86
github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/preprocess.Preprocess()
        /home/yyang/opentelemetry-go-auto-instrumentation/tool/preprocess/preprocess.go:767 +0x136
main.main()
        /home/yyang/opentelemetry-go-auto-instrumentation/tool/cmd/main.go:184 +0x92

Detail.reason: package xxx is not in std (/usr/local/go/src/xxx)

Detail.command: [go build -a -x -n xxx]

```