### PR TITLE
Fix cmd err in README of example/extension

### DIFF
--- a/example/extension/nethttp/README.md
+++ b/example/extension/nethttp/README.md
@@ -20,7 +20,7 @@ Use `otel` to build the binary with `config.json`:
 ```
 cd example/extension/nethttp
 ../../../otel set -rule=config.json
-../../../otel -rule=config.json go build demo/net_http.go
+../../../otel go build demo/net_http.go
 ```
 Users can get the `otel` according to [documentation](../../../README.md)
 


### PR DESCRIPTION
The original compilation cmd `../../../otel -rule=config.json go build demo/net_http.go` is invalid and the arg `-rule` should be removed.