### PR TITLE
Fix arch detection error in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 MAIN_VERSION := $(shell git describe --tags `git rev-list --tags --max-count=1` | sed 's/^v//')
 
 CURRENT_OS := $(shell uname -s | tr '[:upper:]' '[:lower:]')
-CURRENT_ARCH := $(shell uname -m)
+CURRENT_ARCH := $(shell uname -m | sed 's/aarch64/arm64/;s/armv7l/arm/;s/armv6l/arm/')
 
 MOD_NAME := github.com/alibaba/opentelemetry-go-auto-instrumentation
 STRIP_DEBUG := -s -w


### PR DESCRIPTION
When use `uname -m` in ARM Linux, the output is `aarch64` that cannot be recognized by Go, which means go build will fail with "unsupported GOOS/GOARCH pair linux/aarch64". Actually `aarch64` should be replaced with `arm64`.