### PR TITLE
fix: ignore vendor when explicitly required

### DIFF
--- a/test/helloworld_test.go
+++ b/test/helloworld_test.go
@@ -19,6 +19,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"testing"
+
+	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/util"
 )
 
 const HelloworldAppName = "helloworld"
@@ -85,4 +87,11 @@ func TestBuildHelloworldWithVendor3(t *testing.T) {
 	UseApp(HelloworldAppName)
 	runModVendor(t)
 	RunGoBuild(t, "go", "build", "-mod", "vendor")
+}
+
+func TestBuildHelloworldWithVendor4(t *testing.T) {
+	UseApp(HelloworldAppName)
+	runModVendor(t)
+	RunGoBuild(t, "go", "build", "-mod=mod")
+	ExpectPreprocessNotContains(t, util.DebugLogFile, "run go mod vendor")
 }

--- a/tool/instrument/inst_func.go
+++ b/tool/instrument/inst_func.go
@@ -68,6 +68,7 @@ func (rp *RuleProcessor) restoreAst(filePath string, root *dst.File) (string, er
 		return arg == filePath
 	})
 	if err != nil {
+		err = errc.Adhere(err, "filePath", filePath)
 		err = errc.Adhere(err, "compileArgs", strings.Join(rp.compileArgs, " "))
 		err = errc.Adhere(err, "newArg", newFile)
 		return "", err

--- a/tool/preprocess/setup.go
+++ b/tool/preprocess/setup.go
@@ -294,6 +294,10 @@ func (dp *DepProcessor) initRules() (err error) {
 
 	// Write to ${GOMOD.DIR}/otel_rules/otel_setup_inst.go
 	initTarget := dp.generatedOf(filepath.Join(OtelRules, OtelSetupInst))
+	err = os.MkdirAll(filepath.Dir(initTarget), 0777)
+	if err != nil {
+		return err
+	}
 	_, err = util.WriteFile(initTarget, c)
 	if err != nil {
 		return err


### PR DESCRIPTION
ignore vendor when explicitly required by using `go build -buildmode=mod` flag