### PR TITLE
fix: adjust line number via //line directive

### DIFF
--- a/test/errors_test.go
+++ b/test/errors_test.go
@@ -48,12 +48,12 @@ func TestRunErrors(t *testing.T) {
 	}
 	re = regexp.MustCompile(".*OtelOnEnterTrampoline_p1.*")
 	matches = re.FindAllString(text, -1)
-	if len(matches) != 3 {
-		t.Fatalf("expecting 3 matches")
+	if len(matches) != 4 {
+		t.Fatalf("expecting 4 matches")
 	}
 	re = regexp.MustCompile(".*OtelOnExitTrampoline_p2.*")
 	matches = re.FindAllString(text, -1)
-	if len(matches) != 3 {
-		t.Fatalf("expecting 3 matches")
+	if len(matches) != 4 {
+		t.Fatalf("expecting 4 matches")
 	}
 }

--- a/test/errorstest/auxiliary/helper.go
+++ b/test/errorstest/auxiliary/helper.go
@@ -21,8 +21,10 @@ func TestSkip() *int {
 func TestSkip2() int {
 	return 1024
 }
-func p1() {}
-func p2() {}
+func p1() { /*Test*/ }
+func p2() { // Test
+}
+
 func p3(arg1 int, arg2 bool, arg3 float64) (int, bool, float64) {
 	return arg1, arg2, arg3
 }

--- a/test/helloworld_test.go
+++ b/test/helloworld_test.go
@@ -51,7 +51,7 @@ func TestRunHelloworld(t *testing.T) {
 	ExpectContains(t, stderr, "BYD")
 
 	text := ReadInstrumentLog(t, filepath.Join("fmt", "print.go"))
-	re := regexp.MustCompile(".*OtelOnEnterTrampoline.*OtelOnExitTrampoline.*")
+	re := regexp.MustCompile("//line <generated>:1")
 	matches := re.FindAllString(text, -1)
 	if len(matches) < 1 {
 		t.Fatalf("expecting at least one match")

--- a/tool/instrument/instrument.go
+++ b/tool/instrument/instrument.go
@@ -37,7 +37,8 @@ import (
 type RuleProcessor struct {
 	packageName     string
 	workDir         string
-	target          *dst.File // The target file to be instrumented
+	target          *dst.File       // The target file to be instrumented
+	parser          *util.AstParser // The parser for the target file
 	compileArgs     []string
 	rule2Suffix     map[*resource.InstFuncRule]string
 	rawFunc         *dst.FuncDecl

--- a/tool/instrument/template.go
+++ b/tool/instrument/template.go
@@ -15,6 +15,7 @@
 // limitations under the License.
 package instrument
 
+//line <generated>:1
 // Seeing is not always believing. The following template is a bit tricky, see
 // trampoline.go for more details
 

--- a/tool/instrument/trampoline.go
+++ b/tool/instrument/trampoline.go
@@ -71,7 +71,8 @@ var trampolineTemplate string
 func (rp *RuleProcessor) materializeTemplate() error {
 	// Read trampoline template and materialize onEnter and onExit function
 	// declarations based on that
-	astRoot, err := util.ParseAstFromSource(trampolineTemplate)
+	p := util.NewAstParser()
+	astRoot, err := p.ParseSource(trampolineTemplate)
 	if err != nil {
 		return err
 	}

--- a/tool/preprocess/preprocess.go
+++ b/tool/preprocess/preprocess.go
@@ -18,6 +18,8 @@ import (
 	"bufio"
 	"embed"
 	"fmt"
+	"go/parser"
+	"go/token"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -31,6 +33,7 @@ import (
 	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/errc"
 	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/resource"
 	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/util"
+	"github.com/dave/dst"
 	"golang.org/x/mod/modfile"
 	"golang.org/x/tools/go/packages"
 )
@@ -536,7 +539,8 @@ func (dp *DepProcessor) addExplicitImport(importPaths ...string) (err error) {
 		if !util.IsGoFile(file) {
 			continue
 		}
-		astRoot, err := util.ParseAstFromFile(file)
+		p := util.NewAstParser()
+		astRoot, err := p.ParseFile(file, parser.ParseComments)
 		if err != nil {
 			return err
 		}
@@ -549,13 +553,40 @@ func (dp *DepProcessor) addExplicitImport(importPaths ...string) (err error) {
 			}
 		}
 
-		// Prepend import path to the file
-		for _, importPath := range importPaths {
-			util.AddImportForcely(astRoot, importPath)
-			if config.GetConf().Verbose {
-				util.Log("Add %s import to %v", importPath, file)
+		// Mark original line number of first import declaration
+		for _, decl := range astRoot.Decls {
+			decl, ok := decl.(*dst.GenDecl)
+			if !ok {
+				continue
 			}
+			if decl.Tok != token.IMPORT {
+				continue
+			}
+			// The node is already tagged with line directive, dont tag it again
+			generated := false
+			if len(decl.Decs.Start) > 0 {
+				for _, dec := range decl.Decs.Start {
+					if strings.Contains(dec, "<generated>:1") {
+						generated = true
+						break
+					}
+				}
+				if generated {
+					break
+				}
+			}
+			pos := p.FindPosition(decl)
+			tag := fmt.Sprintf("//line %v", pos.String())
+			decl.Decs.Before = dst.NewLine
+			decl.Decs.Start.Append(tag)
+			break
 		}
+		//  Prepend the generated import with a line directive to indicate
+		//  that the generated code is not part of the original source code.
+		util.Log("Add %v import to %v", importPaths, file)
+		importDecl := util.AddImportForcely(astRoot, importPaths...)
+		importDecl.Decs.Before = dst.NewLine
+		importDecl.Decs.Start.Append("//line <generated>:1")
 		addImport = true
 
 		err = dp.backupFile(file)

--- a/tool/preprocess/setup.go
+++ b/tool/preprocess/setup.go
@@ -171,7 +171,8 @@ func (dp *DepProcessor) copyRule(path, target string,
 		return err
 	}
 	text = util.RemoveGoBuildComment(text)
-	astRoot, err := util.ParseAstFromSource(text)
+	p := util.NewAstParser()
+	astRoot, err := p.ParseSource(text)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
related to #247 

adjust line number via `//line` directive, something like this
```go
package main

//line <generated>
import _ "httpclient/otel_rules"

//line <generated>
import (
	_ "go.opentelemetry.io/otel"
	_ "go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
	_ "go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
	_ "go.opentelemetry.io/otel/exporters/otlp/otlptrace"
	_ "go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
	_ "go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
	_ "go.opentelemetry.io/otel/exporters/prometheus"
)

//line app4.go:17:1
import (
	"context"
	"net/http"
)
```
```go
func TestSkip2() (retVal0 int) {
	//line <generated>
	if callContext30412, skip30412 := OtelOnEnterTrampoline_TestSkip230412(); skip30412 {
		OtelOnExitTrampoline_TestSkip230412(callContext30412, &retVal0)
		return retVal0
	} else {
		defer OtelOnExitTrampoline_TestSkip230412(callContext30412, &retVal0)
	}
	//line helper.go:22:2
	return 1024
}
func p1() {
	//line <generated>
	if OtelOnEnterTrampoline_p154858(); false {
	} else {
		if OtelOnEnterTrampoline_p160483(); false {
		} else {
		}
	}
	//line helper.go:24:11
}
```