### PR TITLE
fix: unable to match target func with generic type receiver

### DIFF
--- a/docs/how-to-add-a-new-rule.md
+++ b/docs/how-to-add-a-new-rule.md
@@ -50,7 +50,7 @@ Create a `rule.json` file to specify the target function and hook code:
 - `OnEnter`: The hook code
 - `Path`: Directory containing the hook code.
 
-Additional fields like `OnExit` and `Order` can also be specified. Refer to [the documentation](rule_def.md) for details.
+Additional fields like `ReceiverType`, `OnExit` and `Order` can also be specified. Refer to [the documentation](rule_def.md) for details.
 
 ## 3. Verify the Rule
 Test the rule with a simple program:

--- a/docs/rule_def.md
+++ b/docs/rule_def.md
@@ -10,6 +10,8 @@
 - `Path`: The path to the directory containing the probe code. The path can be either go module url or local file system path, e.g. `github.com/foo/bar` or `/path/to/probe/code`.
 - `Version`: The version of the package that contains the function to be instrumented. e.g. `[1.0.0,1.1.0)`, the version range is `[1.0.0,1.1.0)`, which means the version is greater than or equal to `1.0.0` and less than `1.1.0`.
 
+> ![IMPORTANT]
+> We dont support generic types in the `ReceiverType` field now.
 
 ## Add a new file during compiling package
 - `ImportPath`: The import path of the package that contains the function to be instrumented.

--- a/test/errorstest/auxiliary/helper.go
+++ b/test/errorstest/auxiliary/helper.go
@@ -33,6 +33,13 @@ func TestGetSet(arg1 int, arg2, arg3 bool, arg4 float64, arg5 string,
 	return arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10
 }
 
+type GenericRecv[T any] struct{ X T }
+type GenericRecv2[T any] struct{ X T }
+
+func (t *GenericRecv[T]) TestGetSetRecv() {}
+
+func (t GenericRecv2[T]) TestGetSetRecv() {}
+
 type Recv struct{ X int }
 
 func (t *Recv) TestGetSetRecv(arg1 int, arg2 float64) (int, float64) {

--- a/tool/util/ast.go
+++ b/tool/util/ast.go
@@ -352,11 +352,19 @@ func MatchFuncDecl(decl dst.Decl, function string, receiverType string) bool {
 		}
 		switch recvTypeExpr := funcDecl.Recv.List[0].Type.(type) {
 		case *dst.StarExpr:
+			if _, ok := recvTypeExpr.X.(*dst.Ident); !ok {
+				// This is a generic type, we don't support it yet
+				return false
+			}
 			return "*"+recvTypeExpr.X.(*dst.Ident).Name == receiverType
 		case *dst.Ident:
 			return recvTypeExpr.Name == receiverType
+		case *dst.IndexExpr:
+			// This is a generic type, we don't support it yet
+			return false
 		default:
-			Unimplemented()
+			msg := fmt.Sprintf("unexpected receiver type: %T", recvTypeExpr)
+			UnimplementedT(msg)
 		}
 	} else {
 		if HasReceiver(funcDecl) {


### PR DESCRIPTION
related to #349 

We prevent otel from crashing, but even after this patch is merged, matching receiver types with generics will still not be supported.