### PR TITLE
fix span timestamp(duration) error with `StartAndEnd()`

### DIFF
--- a/pkg/inst-api/instrumenter/instrumenter.go
+++ b/pkg/inst-api/instrumenter/instrumenter.go
@@ -104,7 +104,7 @@ func (i *InternalInstrumenter[REQUEST, RESPONSE]) doStart(parentContext context.
 	// extract span name
 	spanName := i.spanNameExtractor.Extract(request)
 	spanKind := i.spanKindExtractor.Extract(request)
-	options = append(options, trace.WithSpanKind(spanKind))
+	options = append(options, trace.WithSpanKind(spanKind), trace.WithTimestamp(timestamp))
 	newCtx, span := i.tracer.Start(parentContext, spanName, options...)
 	attrs := make([]attribute.KeyValue, 0, 20)
 	// extract span attrs


### PR DESCRIPTION
Ref https://github.com/alibaba/opentelemetry-go-auto-instrumentation/issues/345

CC @NameHaibinZhang I've fixed this issue.

Before:
<img width="1920" alt="Clipboard_Screenshot_1741998332" src="https://github.com/user-attachments/assets/db9a6b98-ff56-45c6-bb26-9ee533963af7" />


After:
<img width="1920" alt="Clipboard_Screenshot_1741998301" src="https://github.com/user-attachments/assets/334f1ec8-da05-473a-bc6e-f9ddc1c5df40" />
