### PR TITLE
feat: regexp based instrumentation point

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![](https://shields.io/badge/Docs-English-blue?logo=Read%20The%20Docs)](./README.md)
 [![](https://shields.io/badge/Readme-中文-blue?logo=Read%20The%20Docs)](./docs/README_CN.md)
 [![codecov](https://codecov.io/gh/alibaba/opentelemetry-go-auto-instrumentation/branch/main/graph/badge.svg)](https://codecov.io/gh/alibaba/opentelemetry-go-auto-instrumentation)
+[![](https://shields.io/badge/Commercial-Aliyun-orange?logo=alibabacloud)](https://help.aliyun.com/zh/arms/application-monitoring/getting-started/monitoring-the-golang-applications)
 
 This project provides an automatic solution for Golang applications that want to
 leverage OpenTelemetry to enable effective observability. No code changes are
@@ -44,15 +45,12 @@ The configuration for the tool can be set by the following command:
 
 ```bash
 $ otel set -verbose                          # print verbose logs
-$ otel set -log=/path/to/file.log            # set log file
 $ otel set -debug                            # enable debug mode
-$ otel set -debug -verbose -rule=custom.json # set multiple configs
-$ otel set -disabledefault -rule=custom.json # disable default rules, use custom rules only
 $ otel set -rule=custom.json                 # use default and custom rules
-$ otel set -rule=a.json,b.json               # use default, a and b rules
+$ otel set -debug -verbose -rule=custom.json # set multiple configs
 ```
 
-Once all set up, add `otel` prefix to `go build` to build your project:
+Normally, you don't need to set any configurations. Just adding `otel` prefix to `go build` to build your project:
 
 ```bash
 $ otel go build
@@ -60,14 +58,7 @@ $ otel go build -o app cmd/app
 $ otel go build -gcflags="-m" cmd/app
 ```
 
-The arguments of the tool itself should be placed before `go build`:
-
-```bash
-$ otel -help # print help document
-$ otel -debug go build # enable debug mode
-$ otel -verbose go build # print verbose logs
-$ otel -rule=custom.json go build # use custom rules
-```
+That's the whole process! The tool will automatically instrument your code with OpenTelemetry, and you can start to observe your application. :telescope:
 
 The detailed usage of `otel` tool can be found in [**Usage**](./docs/usage.md).
 

--- a/docs/rule_def.md
+++ b/docs/rule_def.md
@@ -2,7 +2,7 @@
 
 ## Instument a function
 - `ImportPath`: The import path of the package that contains the function to be instrumented. e.g. `net/http`.
-- `Function`: The name of the function to be instrumented.
+- `Function`: The name of the function to be instrumented, it could be a regular expression to match multiple functions. e.g. `.*` matches all functions in the package, `.*ServeHTTP` matches all functions whose name ends with `ServeHTTP`, and so on.
 - `ReceiverType`: The type of the receiver of the function to be instrumented. e.g. `*http.Server`, `http.Server`.
 - `OnEnter`: The name of the function to be called when the instrumented function is called. e.g. `clientOnEnter`.
 - `OnExit`: The name of the function to be called when the instrumented function returns. e.g. `clientOnExit`.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/alibaba/opentelemetry-go-auto-instrumentation
 
-go 1.23
+go 1.23.0
 
 replace github.com/alibaba/opentelemetry-go-auto-instrumentation/test/verifier => ./test/verifier
 

--- a/pkg/data/test_error.json
+++ b/pkg/data/test_error.json
@@ -112,5 +112,17 @@
         "Function": "TargetWithFuncType",
         "OnEnter": "onEnterTargetWithFuncType",
         "Path": "github.com/alibaba/opentelemetry-go-auto-instrumentation/pkg/rules/test/error18"
+    },
+    {
+        "ImportPath": "errorstest/all",
+        "Function": ".*",
+        "OnEnter": "onEnterGeneric",
+        "Path": "github.com/alibaba/opentelemetry-go-auto-instrumentation/pkg/rules/test/error19"
+    },
+    {
+        "ImportPath": "errorstest/all",
+        "Function": "f[12]",
+        "OnEnter": "onEnterGeneric2",
+        "Path": "github.com/alibaba/opentelemetry-go-auto-instrumentation/pkg/rules/test/error19"
     }
 ]

--- a/pkg/rules/test/error19/hook.go
+++ b/pkg/rules/test/error19/hook.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2025 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package error19
+
+import (
+	"github.com/alibaba/opentelemetry-go-auto-instrumentation/pkg/api"
+)
+
+// onEnterGeneric is a generic hook function that can be used to handle all
+// entry points of a function. The only parameter is a CallContext, which
+// contains all the information about the function call.
+func onEnterGeneric(call api.CallContext) {
+	println("xian")
+}
+
+func onEnterGeneric2(call api.CallContext) {
+	println("shanxi")
+}

--- a/test/errors_test.go
+++ b/test/errors_test.go
@@ -56,4 +56,16 @@ func TestRunErrors(t *testing.T) {
 	if len(matches) != 4 {
 		t.Fatalf("expecting 4 matches")
 	}
+
+	// Test for generic hook
+	re = regexp.MustCompile(".*xian.*")
+	matches = re.FindAllString(stderr, -1)
+	if len(matches) != 4 { // f1 + f2 + f4 + init
+		t.Fatalf("expecting 4 matches")
+	}
+	re = regexp.MustCompile(".*shanxi.*") // f1 + f2
+	matches = re.FindAllString(stderr, -1)
+	if len(matches) != 2 {
+		t.Fatalf("expecting 2 matches")
+	}
 }

--- a/test/errorstest/all/match.go
+++ b/test/errorstest/all/match.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2025 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package all
+
+func f1() {}
+
+func f2(a string) {}
+
+type recv int
+
+func (r *recv) f3() {}
+
+func f4() int { return 7632 }
+
+func init() {
+	f1()
+	f2("shanxi")
+	new(recv).f3()
+	f4()
+}

--- a/test/errorstest/main.go
+++ b/test/errorstest/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"errors"
+	_ "errorstest/all"
 	"errorstest/auxiliary"
 	_ "errorstest/dep"
 	"fmt"

--- a/tool/instrument/instrument.go
+++ b/tool/instrument/instrument.go
@@ -42,6 +42,7 @@ type RuleProcessor struct {
 	compileArgs     []string
 	rule2Suffix     map[*resource.InstFuncRule]string
 	rawFunc         *dst.FuncDecl
+	exact           bool // If the rule is exact match with target function
 	onEnterHookFunc *dst.FuncDecl
 	onExitHookFunc  *dst.FuncDecl
 	varDecls        []dst.Decl

--- a/tool/instrument/optimize.go
+++ b/tool/instrument/optimize.go
@@ -185,8 +185,7 @@ func (rp *RuleProcessor) removeOnEnterTrampolineCall(tjump *TJump) error {
 	// Remove generated onEnter trampoline function
 	removed := rp.removeDeclWhen(func(d dst.Decl) bool {
 		if funcDecl, ok := d.(*dst.FuncDecl); ok {
-			return funcDecl.Name.Name == rp.makeName(tjump.rule, true)
-
+			return funcDecl.Name.Name == rp.makeName(tjump.rule, tjump.target, true)
 		}
 		return false
 	})

--- a/tool/util/ast.go
+++ b/tool/util/ast.go
@@ -20,6 +20,7 @@ import (
 	"go/token"
 	"os"
 	"path/filepath"
+	"regexp"
 
 	"github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/errc"
 	"github.com/dave/dst"
@@ -338,12 +339,20 @@ func FindFuncDecl(root *dst.File, name string) *dst.FuncDecl {
 	return nil
 }
 
+func isValidRegex(pattern string) bool {
+	_, err := regexp.Compile(pattern)
+	return err == nil
+}
+
 func MatchFuncDecl(decl dst.Decl, function string, receiverType string) bool {
+	Assert(isValidRegex(function), "invalid function name pattern")
+
 	funcDecl, ok := decl.(*dst.FuncDecl)
 	if !ok {
 		return false
 	}
-	if funcDecl.Name.Name != function {
+	re := regexp.MustCompile("^" + function + "$") // strict match
+	if !re.MatchString(funcDecl.Name.Name) {
 		return false
 	}
 	if receiverType != "" {
@@ -371,7 +380,6 @@ func MatchFuncDecl(decl dst.Decl, function string, receiverType string) bool {
 			return false
 		}
 	}
-
 	return true
 }
 


### PR DESCRIPTION
We can use regexp in the rules to match one or more target functions. Something like this
```json
  {
        "ImportPath": "errorstest/auxiliary",
        "Function": ".*",
        "OnEnter": "onEnterGeneric",
        "Path": "github.com/alibaba/opentelemetry-go-auto-instrumentation/pkg/rules/test/error19"
    }
```