### PR TITLE
fix: stop finding for go.mod if root is reached

### DIFF
--- a/tool/preprocess/preprocess.go
+++ b/tool/preprocess/preprocess.go
@@ -190,7 +190,11 @@ func findGoMod(dir string) (string, error) {
 		if util.PathExists(mod) {
 			return mod, nil
 		}
-		dir = filepath.Dir(dir)
+		par := filepath.Dir(dir)
+		if par == dir {
+			break
+		}
+		dir = par
 	}
 	return "", errc.New(errc.ErrPreprocess, "cannot find go.mod")
 }


### PR DESCRIPTION
stop finding for `go.mod` if root is reached