### PR TITLE
Fix incorrect status code extraction in grpcStatusCodeExtractor

### DIFF
--- a/pkg/rules/grpc/grpc_otel_instrumenter.go
+++ b/pkg/rules/grpc/grpc_otel_instrumenter.go
@@ -72,7 +72,7 @@ type grpcStatusCodeExtractor[REQUEST grpcRequest, RESPONSE grpcResponse] struct 
 
 func (g grpcStatusCodeExtractor[REQUEST, RESPONSE]) Extract(span trace.Span, request grpcRequest, response grpcResponse, err error) {
 	statusCode := response.statusCode
-	if statusCode != 0 {
+	if statusCode != 200 {
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())


### PR DESCRIPTION
This PR fixes an issue in grpcStatusCodeExtractor where it incorrectly judgment here should be 200 instead of 0.