### PR TITLE
fix: circular dependency log

### DIFF
--- a/tool/preprocess/setup.go
+++ b/tool/preprocess/setup.go
@@ -264,18 +264,20 @@ func (dp *DepProcessor) initRules() (err error) {
 							),
 						)
 					}
-					assigns = append(assigns, fmt.Sprintf(
-						"\t%s.%s = %s\n",
-						aliasPkg,
-						OtelGetStackDef,
-						OtelGetStackImplCode,
-					))
-					assigns = append(assigns, fmt.Sprintf(
-						"\t%s.%s = %s\n",
-						aliasPkg,
-						OtelPrintStackDef,
-						OtelPrintStackImplCode,
-					))
+					if bundle.PackageName != OtelPrintStackImportPath {
+						assigns = append(assigns, fmt.Sprintf(
+							"\t%s.%s = %s\n",
+							aliasPkg,
+							OtelGetStackDef,
+							OtelGetStackImplCode,
+						))
+						assigns = append(assigns, fmt.Sprintf(
+							"\t%s.%s = %s\n",
+							aliasPkg,
+							OtelPrintStackDef,
+							OtelPrintStackImplCode,
+						))
+					}
 				}
 			}
 		}


### PR DESCRIPTION
https://github.com/alibaba/opentelemetry-go-auto-instrumentation/issues/421
fix: conditionally assign stack definitions based on package name ，Solve the problem of circular dependency