### PR TITLE
fix: fix otel_importer.go not found error

### DIFF
--- a/tool/preprocess/preprocess.go
+++ b/tool/preprocess/preprocess.go
@@ -190,7 +190,22 @@ func (dp *DepProcessor) initMod() (err error) {
 					}
 				}
 				if !found {
-					dp.goBuildCmd = append(dp.goBuildCmd, OtelImporter)
+					var importerPath string
+					lastPackage := dp.goBuildCmd[len(dp.goBuildCmd)-1]
+					if filepath.IsAbs(lastPackage) {
+						importerPath = dp.generatedOf(OtelImporter)
+					} else {
+						workdir, err := os.Getwd()
+						if err != nil {
+							return err
+						}
+						relativePath, err := filepath.Rel(workdir, dp.getGoModDir())
+						if err != nil {
+							return err
+						}
+						importerPath = filepath.Join(relativePath, OtelImporter)
+					}
+					dp.goBuildCmd = append(dp.goBuildCmd, importerPath)
 				}
 			}
 		}


### PR DESCRIPTION
In this PR, fixed the issue that otel_importer.go was not found.

An error occurs when running the `otel go build -o ./bin/auth ./auth/main.go`  command.

error:
```
===== Environments =====
Command    : otel go build -o ./bin/auth ./auth/main.go
ErrorLog   : .otel-build/preprocess/debug.log
WorkDir    : /Users/deven/Workspace/projectname
Toolchain  : darwin/amd64, go1.24.2, _15c5dd0
===== Fatal Error ======
Error      : Failed to run command
Reason     : exit status 1
Cause      : goroutine 1 [running]:
runtime/debug.Stack()
        /usr/local/go/src/runtime/debug/stack.go:26 +0x5e
github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/errc.New(0x3f6, {0xc000292d10, 0xd})
        tool/errc/errcode.go:99 +0xc5
github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/preprocess.runDryBuild({0xc000260dc0, 0x6, 0xa})
        tool/preprocess/preprocess.go:560 +0x385
github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/preprocess.(*DepProcessor).matchRules(0xc000039e78)
        tool/preprocess/match.go:523 +0xd9
github.com/alibaba/opentelemetry-go-auto-instrumentation/tool/preprocess.Preprocess()
        tool/preprocess/preprocess.go:792 +0x1a5
main.main()
        tool/otel/main.go:169 +0x9b

Detail.reason: stat otel_importer.go: no such file or directory

Detail.command: [go build -a -x -n -o ./bin/auth ./auth/main.go otel_importer.go]
```