### PR TITLE
Add rpc.grpc.status_code attribute to gRPC metrics

### DIFF
--- a/pkg/inst-api-semconv/instrumenter/rpc/rpc_attrs_extractor.go
+++ b/pkg/inst-api-semconv/instrumenter/rpc/rpc_attrs_extractor.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,6 +19,7 @@ import (
 	"github.com/alibaba/opentelemetry-go-auto-instrumentation/pkg/inst-api/utils"
 	"go.opentelemetry.io/otel/attribute"
 	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
+	"google.golang.org/grpc/status"
 )
 
 // TODO: remove server.address and put it into NetworkAttributesExtractor
@@ -45,6 +46,22 @@ func (r *RpcAttrsExtractor[REQUEST, RESPONSE, GETTER]) OnStart(attributes []attr
 }
 
 func (r *RpcAttrsExtractor[REQUEST, RESPONSE, GETTER]) OnEnd(attributes []attribute.KeyValue, context context.Context, request REQUEST, response RESPONSE, err error) ([]attribute.KeyValue, context.Context) {
+	// Extract gRPC status code if error is present
+	if err != nil {
+		// Convert error to gRPC status code
+		if st, ok := status.FromError(err); ok {
+			attributes = append(attributes, attribute.KeyValue{
+				Key:   semconv.RPCGRPCStatusCodeKey,
+				Value: attribute.IntValue(int(st.Code())),
+			})
+		}
+	} else {
+		// Default to OK (0) status code for successful responses
+		attributes = append(attributes, attribute.KeyValue{
+			Key:   semconv.RPCGRPCStatusCodeKey,
+			Value: attribute.IntValue(0),
+		})
+	}
 	return attributes, context
 }
 

--- a/pkg/inst-api-semconv/instrumenter/rpc/rpc_metrics.go
+++ b/pkg/inst-api-semconv/instrumenter/rpc/rpc_metrics.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      rpc://www.apache.org/licenses/LICENSE-2.0
+//     rpc://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -32,22 +32,23 @@ const rpc_server_request_duration = "rpc.server.duration"
 const rpc_client_request_duration = "rpc.client.duration"
 
 type RpcServerMetric struct {
-	key                   attribute.Key
+	key                    attribute.Key
 	serverRequestDuration metric.Float64Histogram
 }
 
 type RpcClientMetric struct {
-	key                   attribute.Key
+	key                    attribute.Key
 	clientRequestDuration metric.Float64Histogram
 }
 
 var mu sync.Mutex
 
 var rpcMetricsConv = map[attribute.Key]bool{
-	semconv.RPCSystemKey:     true,
-	semconv.RPCMethodKey:     true,
-	semconv.RPCServiceKey:    true,
+	semconv.RPCSystemKey:    true,
+	semconv.RPCMethodKey:    true,
+	semconv.RPCServiceKey:   true,
 	semconv.ServerAddressKey: true,
+	semconv.RPCGRPCStatusCodeKey: true,
 }
 
 var globalMeter metric.Meter
@@ -84,7 +85,7 @@ func newRpcServerRequestDurationMeasures(meter metric.Meter) (metric.Float64Hist
 	if err == nil {
 		return d, nil
 	} else {
-		return d, errors.New(fmt.Sprintf("failed to create rpc.server.request.duratio histogram, %v", err))
+		return d, errors.New(fmt.Sprintf("failed to create rpc.server.request.duration histogram, %v", err))
 	}
 }
 
@@ -100,7 +101,7 @@ func newRpcClientRequestDurationMeasures(meter metric.Meter) (metric.Float64Hist
 	if err == nil {
 		return d, nil
 	} else {
-		return d, errors.New(fmt.Sprintf("failed to create rpc.client.request.duratio histogram, %v", err))
+		return d, errors.New(fmt.Sprintf("failed to create rpc.client.request.duration histogram, %v", err))
 	}
 }
 


### PR DESCRIPTION
This PR adds the `rpc.grpc.status_code` attribute to gRPC metrics instrumentation, following OpenTelemetry semantic conventions.

## Changes
- Added `RPCGRPCStatusCodeKey` to the metrics attribute filter in `rpc_metrics.go`
- Enhanced the RPC attribute extractor to extract gRPC status codes from errors using `status.FromError()`
- Added status code attribute to both successful (0/OK) and error responses
- Ensures status codes are properly captured in all gRPC metrics

## Benefits
- Enables filtering and aggregation of metrics by status code
- Allows for better error rate monitoring and debugging
- Follows OpenTelemetry semantic conventions
- Improves observability by adding dimensionality to metrics

## Testing
- Verified status codes are properly extracted from errors
- Confirmed metrics are correctly recorded with the new attribute
- Tested with both successful and error scenarios

This implementation follows the OpenTelemetry semantic conventions for RPC metrics, adding the status code as an attribute to existing metrics rather than creating a new metric.