### PR TITLE
fix: add missing dependency to k8s client-go rule

### DIFF
--- a/test/k8s-client-go/v0.33.3/test_k8s_basic.go
+++ b/test/k8s-client-go/v0.33.3/test_k8s_basic.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2025 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/tool/data/rules/k8s_client_go.json
+++ b/tool/data/rules/k8s_client_go.json
@@ -8,6 +8,7 @@
     "Path": "github.com/alibaba/loongsuite-go-agent/pkg/rules/k8s-client-go",
     "Dependencies": [
       "k8s.io/apimachinery/pkg/runtime",
+      "k8s.io/apimachinery/pkg/api/meta",
       "k8s.io/client-go/kubernetes/scheme"
     ]
   }


### PR DESCRIPTION
Follow-up to #530