### PR TITLE
fix: Use log.Fatalf instead of panic for consistency in init()

### DIFF
--- a/pkg/otel_setup.go
+++ b/pkg/otel_setup.go
@@ -93,7 +93,7 @@ func init() {
 	}
 	path, err := os.Executable()
 	if err != nil {
-		panic(err)
+		log.Fatalf("Failed to get executable path: %v", err)
 	}
 	// skip when the executable is otel itself
 	if strings.HasSuffix(path, exec_name) {


### PR DESCRIPTION
## Summary

Fix error handling inconsistency in the `init()` function by replacing `panic()` with `log.Fatalf()` for better consistency and error reporting.

## Problem

In `pkg/otel_setup.go` line 96, when `os.Executable()` fails, the error is handled with `panic(err)`:

```go
path, err := os.Executable()
if err != nil {
    panic(err)
}
```

However, other initialization errors in the same `init()` function use `log.Fatalf()` (lines 103, 139):
- Line 103: `log.Fatalf("%s: %v", "Failed to initialize opentelemetry resource", err)`
- Line 139: `log.Fatalf("No valid trace exporter configured")`

### Issues with using `panic()` here:

1. **Inconsistency**: The same file uses different error handling methods for similar failures
2. **Poor error messages**: `panic()` produces a stack trace, while `log.Fatalf()` provides a clear, contextual error message
3. **Go best practices**: For initialization failures, `log.Fatalf()` is preferred over `panic()`
4. **Debugging difficulty**: Stack traces from `panic()` can be confusing for simple initialization failures

## Solution

Replace `panic(err)` with `log.Fatalf()` for consistent error handling:

```go
path, err := os.Executable()
if err != nil {
    log.Fatalf("Failed to get executable path: %v", err)
}
```

## Benefits

1. **Consistency**: All initialization errors now use the same error handling method
2. **Better error messages**: Clear error message with context ("Failed to get executable path") instead of just a stack trace
3. **Easier debugging**: Users get a clear message about what went wrong
4. **Follows Go conventions**: `log.Fatalf()` is the standard way to handle initialization failures

## Impact

- **Low risk**: Only changes error handling behavior, no functional changes
- **Improved user experience**: Clearer error messages for debugging
- **Code quality**: More consistent error handling throughout the file

## Test plan

This change only affects error handling during initialization:
- [x] Error message is clearer with context
- [x] Consistent with other error handling in the same file
- [x] Program still terminates on initialization failure (as expected)
- [x] No functional changes to successful initialization path

🤖 Generated with [Claude Code](https://claude.com/claude-code)